### PR TITLE
Remove redundant resource decorators

### DIFF
--- a/openprocurement/auctions/core/plugins/awarding/v1/utils.py
+++ b/openprocurement/auctions/core/plugins/awarding/v1/utils.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
-from openprocurement.api.models import TZ
 from barbecue import chef
-from openprocurement.api.models import get_now
+
+from openprocurement.api.models import TZ, get_now
+from openprocurement.api.utils import (
+    get_awarding_type_by_procurement_method_type
+)
 
 
 def next_check_awarding(auction, checks):
@@ -40,6 +43,9 @@ def next_check_awarding(auction, checks):
 
 def add_next_award(request):
     auction = request.validated['auction']
+    awarding_type = get_awarding_type_by_procurement_method_type(
+        auction.procurementMethodType
+    )
     now = get_now()
     if not auction.awardPeriod:
         auction.awardPeriod = type(auction).awardPeriod({})
@@ -92,7 +98,11 @@ def add_next_award(request):
                     }
                 })
                 auction.awards.append(award)
-                request.response.headers['Location'] = request.route_url('{}:Auction Awards'.format(auction.procurementMethodType), auction_id=auction.id, award_id=award['id'])
+                request.response.headers['Location'] = request.route_url(
+                    '{}:Auction Awards'.format(awarding_type),
+                    auction_id=auction.id,
+                    award_id=award['id']
+                )
                 statuses.add('pending')
             else:
                 statuses.add('unsuccessful')
@@ -119,7 +129,11 @@ def add_next_award(request):
                     }
                 })
                 auction.awards.append(award)
-                request.response.headers['Location'] = request.route_url('{}:Auction Awards'.format(auction.procurementMethodType), auction_id=auction.id, award_id=award['id'])
+                request.response.headers['Location'] = request.route_url(
+                    '{}:Auction Awards'.format(awarding_type),
+                    auction_id=auction.id,
+                    award_id=award['id']
+                )
         if auction.awards[-1].status == 'pending':
             auction.awardPeriod.endDate = None
             auction.status = 'active.qualification'

--- a/openprocurement/auctions/core/plugins/awarding/v1/views/award.py
+++ b/openprocurement/auctions/core/plugins/awarding/v1/views/award.py
@@ -21,7 +21,7 @@ from openprocurement.auctions.core.validation import (
 
 
 @opresource(
-    name='belowThreshold:Auction Awards',
+    name='awarding_1_0:Auction Awards',
     collection_path='/auctions/{auction_id}/awards',
     path='/auctions/{auction_id}/awards/{award_id}',
     awardingType='awarding_1_0',

--- a/openprocurement/auctions/core/plugins/awarding/v1/views/award_complaint.py
+++ b/openprocurement/auctions/core/plugins/awarding/v1/views/award_complaint.py
@@ -22,7 +22,7 @@ from openprocurement.auctions.core.validation import (
 
 
 @opresource(
-    name='belowThreshold:Auction Award Complaints',
+    name='awarding_1_0:Auction Award Complaints',
     collection_path='/auctions/{auction_id}/awards/{award_id}/complaints',
     path='/auctions/{auction_id}/awards/{award_id}/complaints/{complaint_id}',
     awardingType='awarding_1_0',

--- a/openprocurement/auctions/core/plugins/awarding/v1/views/award_complaint_document.py
+++ b/openprocurement/auctions/core/plugins/awarding/v1/views/award_complaint_document.py
@@ -22,7 +22,7 @@ from openprocurement.auctions.core.utils import (
 
 
 @opresource(
-    name='belowThreshold:Auction Award Complaint Documents',
+    name='awarding_1_0:Auction Award Complaint Documents',
     collection_path='/auctions/{auction_id}/awards/{award_id}/complaints/{complaint_id}/documents',
     path='/auctions/{auction_id}/awards/{award_id}/complaints/{complaint_id}/documents/{document_id}',
     awardingType='awarding_1_0',

--- a/openprocurement/auctions/core/plugins/awarding/v1/views/award_document.py
+++ b/openprocurement/auctions/core/plugins/awarding/v1/views/award_document.py
@@ -20,7 +20,7 @@ from openprocurement.auctions.core.utils import (
 
 
 @opresource(
-    name='belowThreshold:Auction Award Documents',
+    name='awarding_1_0:Auction Award Documents',
     collection_path='/auctions/{auction_id}/awards/{award_id}/documents',
     path='/auctions/{auction_id}/awards/{award_id}/documents/{document_id}',
     awardingType='awarding_1_0',

--- a/openprocurement/auctions/core/plugins/awarding/v2/utils.py
+++ b/openprocurement/auctions/core/plugins/awarding/v2/utils.py
@@ -1,6 +1,10 @@
-from openprocurement.api.utils import get_now
-from openprocurement.api.models import TZ
 from barbecue import chef
+
+from openprocurement.api.models import TZ
+from openprocurement.api.utils import (
+    get_now,
+    get_awarding_type_by_procurement_method_type,
+)
 
 
 def create_awards_dgf(request):
@@ -8,6 +12,9 @@ def create_awards_dgf(request):
     auction.status = 'active.qualification'
     now = get_now()
     auction.awardPeriod = type(auction).awardPeriod({'startDate': now})
+    awarding_type = get_awarding_type_by_procurement_method_type(
+        auction.procurementMethodType
+    )
 
     bids = chef(auction.bids, auction.features or [], [], True)
 
@@ -27,13 +34,19 @@ def create_awards_dgf(request):
             award.complaintPeriod.endDate = now
         if award.status == 'pending.verification':
             award.signingPeriod = award.paymentPeriod = award.verificationPeriod = {'startDate': now}
-            request.response.headers['Location'] = request.route_url('{}:Auction Awards'.format(auction.procurementMethodType), auction_id=auction.id, award_id=award['id'])
+            request.response.headers['Location'] = request.route_url(
+                '{}:Auction Awards'.format(awarding_type),
+                auction_id=auction.id, award_id=award['id']
+            )
         auction.awards.append(award)
 
 
 def create_awards_insider(request):
     auction = request.validated['auction']
     auction.status = 'active.qualification'
+    awarding_type = get_awarding_type_by_procurement_method_type(
+        auction.procurementMethodType
+    )
     now = get_now()
     auction.awardPeriod = type(auction).awardPeriod({'startDate': now})
     valid_bids = [bid for bid in auction.bids if bid['status'] != 'invalid']
@@ -52,20 +65,31 @@ def create_awards_insider(request):
         })
         if award.status == 'pending.verification':
             award.signingPeriod = award.paymentPeriod = award.verificationPeriod = {'startDate': now}
-            request.response.headers['Location'] = request.route_url('{}:Auction Awards'.format(auction.procurementMethodType), auction_id=auction.id, award_id=award['id'])
+            request.response.headers['Location'] = request.route_url(
+                '{}:Auction Awards'.format(awarding_type),
+                auction_id=auction.id,
+                award_id=award['id']
+            )
         auction.awards.append(award)
 
 
 def switch_to_next_award(request):
     auction = request.validated['auction']
     now = get_now()
+    awarding_type = get_awarding_type_by_procurement_method_type(
+        auction.procurementMethodType
+    )
     waiting_awards = [i for i in auction.awards if i['status'] == 'pending.waiting']
     if waiting_awards:
         award = waiting_awards[0]
         award.status = 'pending.verification'
         award.signingPeriod = award.paymentPeriod = award.verificationPeriod = {'startDate': now}
         award = award.serialize()
-        request.response.headers['Location'] = request.route_url('{}:Auction Awards'.format(auction.procurementMethodType), auction_id=auction.id, award_id=award['id'])
+        request.response.headers['Location'] = request.route_url(
+            '{}:Auction Awards'.format(awarding_type),
+            auction_id=auction.id,
+            award_id=award['id']
+        )
 
     elif all([award.status in ['cancelled', 'unsuccessful'] for award in auction.awards]):
         auction.awardPeriod.endDate = now

--- a/openprocurement/auctions/core/plugins/awarding/v2/views/award.py
+++ b/openprocurement/auctions/core/plugins/awarding/v2/views/award.py
@@ -21,21 +21,7 @@ from openprocurement.auctions.core.plugins.awarding.v2.utils import (
 
 
 @opresource(
-    name='dgfInsider:Auction Awards',
-    collection_path='/auctions/{auction_id}/awards',
-    path='/auctions/{auction_id}/awards/{award_id}',
-    awardingType='awarding_2_0',
-    description="Insider auction awards"
-)
-@opresource(
-    name='dgfFinancialAssets:Auction Awards',
-    collection_path='/auctions/{auction_id}/awards',
-    path='/auctions/{auction_id}/awards/{award_id}',
-    awardingType='awarding_2_0',
-    description="Financial auction awards"
-)
-@opresource(
-    name='dgfOtherAssets:Auction Awards',
+    name='awarding_2_0:Auction Awards',
     collection_path='/auctions/{auction_id}/awards',
     path='/auctions/{auction_id}/awards/{award_id}',
     awardingType='awarding_2_0',

--- a/openprocurement/auctions/core/plugins/awarding/v2/views/award_complaint.py
+++ b/openprocurement/auctions/core/plugins/awarding/v2/views/award_complaint.py
@@ -19,21 +19,7 @@ from openprocurement.auctions.core.validation import (
 
 
 @opresource(
-    name='dgfInsider:Auction Award Complaints',
-    collection_path='/auctions/{auction_id}/awards/{award_id}/complaints',
-    path='/auctions/{auction_id}/awards/{award_id}/complaints/{complaint_id}',
-    awardingType='awarding_2_0',
-    description="Insider auction award complaints"
-)
-@opresource(
-    name='dgfFinancialAssets:Auction Award Complaints',
-    collection_path='/auctions/{auction_id}/awards/{award_id}/complaints',
-    path='/auctions/{auction_id}/awards/{award_id}/complaints/{complaint_id}',
-    awardingType='awarding_2_0',
-    description="Financial auction award complaints"
-)
-@opresource(
-    name='dgfOtherAssets:Auction Award Complaints',
+    name='awarding_2_0:Auction Award Complaints',
     collection_path='/auctions/{auction_id}/awards/{award_id}/complaints',
     path='/auctions/{auction_id}/awards/{award_id}/complaints/{complaint_id}',
     awardingType='awarding_2_0',

--- a/openprocurement/auctions/core/plugins/awarding/v2/views/award_complaint_document.py
+++ b/openprocurement/auctions/core/plugins/awarding/v2/views/award_complaint_document.py
@@ -20,25 +20,12 @@ from openprocurement.auctions.core.utils import (
 from openprocurement.api.views.complaint_document import STATUS4ROLE
 
 
-
 @opresource(
-    name='dgfInsider:Auction Award Complaint Documents',
-    collection_path='/auctions/{auction_id}/awards/{award_id}/complaints/{complaint_id}/documents',
-    path='/auctions/{auction_id}/awards/{award_id}/complaints/{complaint_id}/documents/{document_id}',
-    awardingType='awarding_2_0',
-    description="Insider auction award complaint documents"
-)
-@opresource(
-    name='dgfFinancialAssets:Auction Award Complaint Documents',
-    collection_path='/auctions/{auction_id}/awards/{award_id}/complaints/{complaint_id}/documents',
-    path='/auctions/{auction_id}/awards/{award_id}/complaints/{complaint_id}/documents/{document_id}',
-    awardingType='awarding_2_0',
-    description="Financial auction award complaint documents"
-)
-@opresource(
-    name='dgfOtherAssets:Auction Award Complaint Documents',
-    collection_path='/auctions/{auction_id}/awards/{award_id}/complaints/{complaint_id}/documents',
-    path='/auctions/{auction_id}/awards/{award_id}/complaints/{complaint_id}/documents/{document_id}',
+    name='awarding_2_0:Auction Award Complaint Documents',
+    collection_path='/auctions/{auction_id}/awards/{award_id}/'
+                    'complaints/{complaint_id}/documents',
+    path='/auctions/{auction_id}/awards/{award_id}/'
+         'complaints/{complaint_id}/documents/{document_id}',
     awardingType='awarding_2_0',
     description="Auction award complaint documents"
 )

--- a/openprocurement/auctions/core/plugins/awarding/v2/views/award_document.py
+++ b/openprocurement/auctions/core/plugins/awarding/v2/views/award_document.py
@@ -20,21 +20,7 @@ from openprocurement.auctions.core.utils import (
 
 
 @opresource(
-    name='dgfInsider:Auction Award Documents',
-    collection_path='/auctions/{auction_id}/awards/{award_id}/documents',
-    path='/auctions/{auction_id}/awards/{award_id}/documents/{document_id}',
-    awardingType='awarding_2_0',
-    description="Insider auction award documents"
-)
-@opresource(
-    name='dgfFinancialAssets:Auction Award Documents',
-    collection_path='/auctions/{auction_id}/awards/{award_id}/documents',
-    path='/auctions/{auction_id}/awards/{award_id}/documents/{document_id}',
-    awardingType='awarding_2_0',
-    description="Financial auction award documents"
-)
-@opresource(
-    name='dgfOtherAssets:Auction Award Documents',
+    name='awarding_2_0:Auction Award Documents',
     collection_path='/auctions/{auction_id}/awards/{award_id}/documents',
     path='/auctions/{auction_id}/awards/{award_id}/documents/{document_id}',
     awardingType='awarding_2_0',

--- a/openprocurement/auctions/core/plugins/contracting/v1/views/contract.py
+++ b/openprocurement/auctions/core/plugins/contracting/v1/views/contract.py
@@ -17,10 +17,10 @@ from openprocurement.auctions.core.validation import (
 )
 
 
-@opresource(name='belowThreshold:Auction Contracts',
+@opresource(name='awarding_1_0:Auction Contracts',
             collection_path='/auctions/{auction_id}/contracts',
             path='/auctions/{auction_id}/contracts/{contract_id}',
-            auctionsprocurementMethodType="belowThreshold",
+            awardingType='awarding_1_0',
             description="Auction contracts")
 class BaseAuctionAwardContractResource(APIResource):
 

--- a/openprocurement/auctions/core/plugins/contracting/v1/views/contract_document.py
+++ b/openprocurement/auctions/core/plugins/contracting/v1/views/contract_document.py
@@ -19,10 +19,10 @@ from openprocurement.auctions.core.utils import (
 )
 
 
-@opresource(name='belowThreshold:Auction Contract Documents',
+@opresource(name='awarding_1_0:Auction Contract Documents',
             collection_path='/auctions/{auction_id}/contracts/{contract_id}/documents',
             path='/auctions/{auction_id}/contracts/{contract_id}/documents/{document_id}',
-            auctionsprocurementMethodType="belowThreshold",
+            awardingType='awarding_1_0',
             description="Auction contract documents")
 class BaseAuctionAwardContractDocumentResource(APIResource):
 

--- a/openprocurement/auctions/core/plugins/contracting/v2/views/contract.py
+++ b/openprocurement/auctions/core/plugins/contracting/v2/views/contract.py
@@ -19,25 +19,12 @@ from openprocurement.auctions.core.validation import (
 )
 
 
+
 @opresource(
-    name='dgfInsider:Auction Contracts',
+    name='awarding_2_0:Auction Contracts',
     collection_path='/auctions/{auction_id}/contracts',
     path='/auctions/{auction_id}/contracts/{contract_id}',
-    auctionsprocurementMethodType="dgfInsider",
-    description="Insider auction contracts"
-)
-@opresource(
-    name='dgfOtherAssets:Auction Contracts',
-    collection_path='/auctions/{auction_id}/contracts',
-    path='/auctions/{auction_id}/contracts/{contract_id}',
-    auctionsprocurementMethodType="dgfOtherAssets",
-    description="Auction contracts"
-)
-@opresource(
-    name='dgfFinancialAssets:Auction Contracts',
-    collection_path='/auctions/{auction_id}/contracts',
-    path='/auctions/{auction_id}/contracts/{contract_id}',
-    auctionsprocurementMethodType="dgfFinancialAssets",
+    awardingType='awarding_2_0',
     description=" Financial auction contracts"
 )
 class BaseAuctionAwardContractResource(APIResource):

--- a/openprocurement/auctions/core/plugins/contracting/v2/views/contract_document.py
+++ b/openprocurement/auctions/core/plugins/contracting/v2/views/contract_document.py
@@ -20,24 +20,12 @@ from openprocurement.auctions.core.utils import (
 
 
 @opresource(
-    name='dgfInsider:Auction Contract Documents',
+    name='awarding_2_0:Auction Contract Documents',
     collection_path='/auctions/{auction_id}/contracts/{contract_id}/documents',
     path='/auctions/{auction_id}/contracts/{contract_id}/documents/{document_id}',
-    auctionsprocurementMethodType="dgfInsider",
-    description="Insider auction contract documents"
+    awardingType='awarding_2_0',
+    description="Financial auction contract documents"
 )
-@opresource(
-    name='dgfOtherAssets:Auction Contract Documents',
-    collection_path='/auctions/{auction_id}/contracts/{contract_id}/documents',
-    path='/auctions/{auction_id}/contracts/{contract_id}/documents/{document_id}',
-    auctionsprocurementMethodType="dgfOtherAssets",
-    description="Auction contract documents"
-)
-@opresource(name='dgfFinancialAssets:Auction Contract Documents',
-            collection_path='/auctions/{auction_id}/contracts/{contract_id}/documents',
-            path='/auctions/{auction_id}/contracts/{contract_id}/documents/{document_id}',
-            auctionsprocurementMethodType="dgfFinancialAssets",
-            description="Financial auction contract documents")
 class BaseAuctionAwardContractDocumentResource(APIResource):
 
     def validate_contract_document(self, operation):


### PR DESCRIPTION
Now awarding-v2 views are routed by awarding type, not by
procurementMethodType.

---
**Depends on [API PR](https://github.com/openprocurement/openprocurement.api/pull/256)**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.auctions.core/26)
<!-- Reviewable:end -->
