### PR TITLE
Update fixture data

### DIFF
--- a/openprocurement/auctions/core/plugins/awarding/v2/tests/award.py
+++ b/openprocurement/auctions/core/plugins/awarding/v2/tests/award.py
@@ -40,7 +40,8 @@ def award_fixture(auction, status, bid_index):
             "startDate": now.isoformat()
         },
         "signingPeriod": {
-            "startDate": now.isoformat()
+            "startDate": now.isoformat(),
+            "endDate": now.isoformat(),
         },
         "verificationPeriod": {
             "startDate": now.isoformat()

--- a/openprocurement/auctions/core/plugins/awarding/v3/tests/blanks/migration_blanks.py
+++ b/openprocurement/auctions/core/plugins/awarding/v3/tests/blanks/migration_blanks.py
@@ -102,7 +102,8 @@ def migrate_contract_pending(self):
         'date': now.isoformat(),
         'items': auction['items'],
         'contractID': '{}-11'.format(auction['auctionID']),
-        'status': 'pending'
+        'status': 'pending',
+        'signingPeriod': active_award['signingPeriod'],
     }]
 
     auction.update(auction)


### PR DESCRIPTION
Contract without `signingPeriod.endDate` will cause error, so I've
added it to fixtures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.auctions.core/47)
<!-- Reviewable:end -->
