### PR TITLE
Update get_plugin_aliases function call

### DIFF
--- a/openprocurement/auctions/core/includeme.py
+++ b/openprocurement/auctions/core/includeme.py
@@ -75,7 +75,7 @@ def includeme(config, plugin_map):
 
     # Aliases information
     LOGGER.info('Start aliases')
-    get_plugin_aliases(plugin_map['plugins'])
+    get_plugin_aliases(plugin_map.get('plugins', {}))
     LOGGER.info('End aliases')
 
     get_evenly_plugins(config, plugin_map['plugins'], 'openprocurement.auctions.core.plugins')


### PR DESCRIPTION
In case core package doesn't have any plugins, empty dictionary will be passed as argument

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.auctions.core/121)
<!-- Reviewable:end -->
