### PR TITLE
Remove redundant next checks for awarding v3.1

### DIFF
--- a/openprocurement/auctions/core/plugins/awarding/v3_1/utils.py
+++ b/openprocurement/auctions/core/plugins/awarding/v3_1/utils.py
@@ -91,15 +91,9 @@ def switch_to_next_award(request):
 
 def next_check_awarding(auction):
     checks = []
-    if awarded_predicate(auction):
-        for contract in auction.contracts:
-            if contract.status == 'pending':
-                checks.append(contract.signingPeriod.endDate.astimezone(TZ))
-    elif not auction.lots and auction.status == 'active.qualification':
+    if not auction.lots and auction.status == 'active.qualification':
         for award in auction.awards:
-            if award.status == 'pending':
-                checks.append(award.verificationPeriod.endDate.astimezone(TZ))
-            elif award.status == 'pending.admission':
+            if award.status == 'pending.admission':
                 checks.append(award.admissionPeriod.endDate.astimezone(TZ))
     elif awarded_and_lots_predicate(auction):
         checks = check_lots_awarding(auction)


### PR DESCRIPTION
Remove signingPeriod.endDate and verificationPeriod.endDate checks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.auctions.core/146)
<!-- Reviewable:end -->
