### PR TITLE
A734478612480132 remove admins token

### DIFF
--- a/openprocurement/auctions/core/tests/award.py
+++ b/openprocurement/auctions/core/tests/award.py
@@ -36,7 +36,9 @@ from openprocurement.auctions.core.tests.blanks.award_blanks import (
 
 
 class AuctionLotAwardResourceTestMixin(object):
-    test_create_auction_award_lot = snitch(create_auction_award_lot)
+    test_create_auction_award_lot = unittest.skip('option not available')(
+        snitch(create_auction_award_lot)
+    )
     test_patch_auction_award_lot = snitch(patch_auction_award_lot)
     test_patch_auction_award_unsuccessful_lot = snitch(patch_auction_award_unsuccessful_lot)
 

--- a/openprocurement/auctions/core/tests/blanks/auction_blanks.py
+++ b/openprocurement/auctions/core/tests/blanks/auction_blanks.py
@@ -58,6 +58,7 @@ def get_auction_auction_not_found(self):
 
 
 def get_auction_auction(self):
+    self.app.authorization = ('Basic', ('auction', ''))
     response = self.app.get('/auctions/{}/auction'.format(self.auction_id), status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
@@ -271,6 +272,7 @@ def post_auction_auction_reversed(self):
 
 
 def get_auction_auction_lot(self):
+        self.app.authorization = ('Basic', ('auction', ''))
         response = self.app.get('/auctions/{}/auction'.format(self.auction_id), status=403)
         self.assertEqual(response.status, '403 Forbidden')
         self.assertEqual(response.content_type, 'application/json')
@@ -681,8 +683,9 @@ def patch_auction_auction_2_lots(self):
                      patch_data["bids"][0]['lotValues'][0]['participationUrl'])
     self.assertEqual(auction["lots"][0]['auctionUrl'], patch_data["lots"][0]['auctionUrl'])
 
-    self.app.authorization = ('Basic', ('token', ''))
-    response = self.app.post_json('/auctions/{}/cancellations'.format(self.auction_id), {'data': {
+    response = self.app.post_json('/auctions/{}/cancellations?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ), {'data': {
         'reason': 'cancellation reason',
         'status': 'active',
         "cancellationOf": "lot",
@@ -778,6 +781,7 @@ def post_auction_auction_document_2_lots(self):
 
 
 def get_auction_features_auction(self):
+    self.app.authorization = ('Basic', ('auction', ''))
     response = self.app.get('/auctions/{}/auction'.format(self.auction_id))
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')

--- a/openprocurement/auctions/core/tests/blanks/bidder_blanks.py
+++ b/openprocurement/auctions/core/tests/blanks/bidder_blanks.py
@@ -21,8 +21,10 @@ def not_found(self):
             u'url', u'name': u'bid_id'}
     ])
 
-    response = self.app.post('/auctions/{}/bids/{}/documents'.format(self.auction_id, self.bid_id), status=404, upload_files=[
-                             ('invalid_value', 'name.doc', 'content')])
+    response = self.app.post('/auctions/{}/bids/{}/documents?acc_token={}'.format(
+        self.auction_id, self.bid_id, self.bid_token),
+        status=404, upload_files=[('invalid_value', 'name.doc', 'content')]
+    )
     self.assertEqual(response.status, '404 Not Found')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['status'], 'error')
@@ -117,8 +119,9 @@ def not_found(self):
 
 
 def create_auction_bidder_document(self):
-    response = self.app.post('/auctions/{}/bids/{}/documents'.format(
-        self.auction_id, self.bid_id), upload_files=[('file', 'name.doc', 'content')])
+    response = self.app.post('/auctions/{}/bids/{}/documents?acc_token={}'.format(
+        self.auction_id, self.bid_id, self.bid_token
+    ), upload_files=[('file', 'name.doc', 'content')])
     self.assertEqual(response.status, '201 Created')
     self.assertEqual(response.content_type, 'application/json')
     doc_id = response.json["data"]['id']
@@ -189,16 +192,18 @@ def create_auction_bidder_document(self):
 
     self.set_status('active.awarded', {'status': 'active.tendering'})
 
-    response = self.app.post('/auctions/{}/bids/{}/documents'.format(
-        self.auction_id, self.bid_id), upload_files=[('file', 'name.doc', 'content')], status=403)
+    response = self.app.post('/auctions/{}/bids/{}/documents?acc_token={}'.format(
+        self.auction_id, self.bid_id, self.bid_token
+    ), upload_files=[('file', 'name.doc', 'content')], status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertIn("Document can be added only during the tendering period: from", response.json['errors'][0]["description"])
 
     self.set_status('active.awarded')
 
-    response = self.app.post('/auctions/{}/bids/{}/documents'.format(
-        self.auction_id, self.bid_id), upload_files=[('file', 'name.doc', 'content')], status=403)
+    response = self.app.post('/auctions/{}/bids/{}/documents?acc_token={}'.format(
+        self.auction_id, self.bid_id, self.bid_token
+    ), upload_files=[('file', 'name.doc', 'content')], status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['errors'][0]["description"], "Can't add document in current (active.awarded) auction status")
@@ -228,16 +233,17 @@ def create_auction_bidder_document(self):
 
 
 def put_auction_bidder_document(self):
-    response = self.app.post('/auctions/{}/bids/{}/documents'.format(
-        self.auction_id, self.bid_id), upload_files=[('file', 'name.doc', 'content')])
+    response = self.app.post('/auctions/{}/bids/{}/documents?acc_token={}'.format(
+        self.auction_id, self.bid_id, self.bid_token
+    ), upload_files=[('file', 'name.doc', 'content')])
     self.assertEqual(response.status, '201 Created')
     self.assertEqual(response.content_type, 'application/json')
     doc_id = response.json["data"]['id']
     self.assertIn(doc_id, response.headers['Location'])
 
-    response = self.app.put('/auctions/{}/bids/{}/documents/{}'.format(self.auction_id, self.bid_id, doc_id),
-                            status=404,
-                            upload_files=[('invalid_name', 'name.doc', 'content')])
+    response = self.app.put('/auctions/{}/bids/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, self.bid_id, doc_id, self.bid_token
+    ), status=404, upload_files=[('invalid_name', 'name.doc', 'content')])
     self.assertEqual(response.status, '404 Not Found')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['status'], 'error')
@@ -246,8 +252,9 @@ def put_auction_bidder_document(self):
             u'body', u'name': u'file'}
     ])
 
-    response = self.app.put('/auctions/{}/bids/{}/documents/{}'.format(
-        self.auction_id, self.bid_id, doc_id), upload_files=[('file', 'name.doc', 'content2')])
+    response = self.app.put('/auctions/{}/bids/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, self.bid_id, doc_id, self.bid_token
+    ), upload_files=[('file', 'name.doc', 'content2')])
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(doc_id, response.json["data"]["id"])
@@ -274,8 +281,9 @@ def put_auction_bidder_document(self):
     self.assertEqual(doc_id, response.json["data"]["id"])
     self.assertEqual('name.doc', response.json["data"]["title"])
 
-    response = self.app.put('/auctions/{}/bids/{}/documents/{}'.format(
-        self.auction_id, self.bid_id, doc_id), 'content3', content_type='application/msword')
+    response = self.app.put('/auctions/{}/bids/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, self.bid_id, doc_id, self.bid_token
+    ), 'content3', content_type='application/msword')
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(doc_id, response.json["data"]["id"])
@@ -297,22 +305,26 @@ def put_auction_bidder_document(self):
 
     self.set_status('active.awarded')
 
-    response = self.app.put('/auctions/{}/bids/{}/documents/{}'.format(
-        self.auction_id, self.bid_id, doc_id), upload_files=[('file', 'name.doc', 'content3')], status=403)
+    response = self.app.put('/auctions/{}/bids/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, self.bid_id, doc_id, self.bid_token
+    ), upload_files=[('file', 'name.doc', 'content3')], status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['errors'][0]["description"], "Can't update document in current (active.awarded) auction status")
 
 
 def patch_auction_bidder_document(self):
-    response = self.app.post('/auctions/{}/bids/{}/documents'.format(
-        self.auction_id, self.bid_id), upload_files=[('file', 'name.doc', 'content')])
+    response = self.app.post('/auctions/{}/bids/{}/documents?acc_token={}'.format(
+        self.auction_id, self.bid_id, self.bid_token
+    ), upload_files=[('file', 'name.doc', 'content')])
     self.assertEqual(response.status, '201 Created')
     self.assertEqual(response.content_type, 'application/json')
     doc_id = response.json["data"]['id']
     self.assertIn(doc_id, response.headers['Location'])
 
-    response = self.app.patch_json('/auctions/{}/bids/{}/documents/{}'.format(self.auction_id, self.bid_id, doc_id), {"data": {
+    response = self.app.patch_json('/auctions/{}/bids/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, self.bid_id, doc_id, self.bid_token
+    ), {"data": {
         "documentOf": "lot"
     }}, status=422)
     self.assertEqual(response.status, '422 Unprocessable Entity')
@@ -322,9 +334,11 @@ def patch_auction_bidder_document(self):
         {u'description': [u'This field is required.'], u'location': u'body', u'name': u'relatedItem'},
     ])
 
-    response = self.app.patch_json('/auctions/{}/bids/{}/documents/{}'.format(self.auction_id, self.bid_id, doc_id), {"data": {
-        "documentOf": "lot",
-        "relatedItem": '0' * 32
+    response = self.app.patch_json('/auctions/{}/bids/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, self.bid_id, doc_id, self.bid_token
+    ), {"data": {
+            "documentOf": "lot",
+            "relatedItem": '0' * 32
     }}, status=422)
     self.assertEqual(response.status, '422 Unprocessable Entity')
     self.assertEqual(response.content_type, 'application/json')
@@ -333,7 +347,9 @@ def patch_auction_bidder_document(self):
         {u'description': [u'relatedItem should be one of lots'], u'location': u'body', u'name': u'relatedItem'}
     ])
 
-    response = self.app.patch_json('/auctions/{}/bids/{}/documents/{}'.format(self.auction_id, self.bid_id, doc_id), {"data": {"description": "document description"}})
+    response = self.app.patch_json('/auctions/{}/bids/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, self.bid_id, doc_id, self.bid_token
+    ), {"data": {"description": "document description"}})
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(doc_id, response.json["data"]["id"])
@@ -347,7 +363,9 @@ def patch_auction_bidder_document(self):
 
     self.set_status('active.awarded')
 
-    response = self.app.patch_json('/auctions/{}/bids/{}/documents/{}'.format(self.auction_id, self.bid_id, doc_id), {"data": {"description": "document description"}}, status=403)
+    response = self.app.patch_json('/auctions/{}/bids/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, self.bid_id, doc_id, self.bid_token
+    ), {"data": {"description": "document description"}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['errors'][0]["description"], "Can't update document in current (active.awarded) auction status")
@@ -356,7 +374,9 @@ def patch_auction_bidder_document(self):
 
 
 def create_auction_bidder_document_json(self):
-    response = self.app.post_json('/auctions/{}/bids/{}/documents'.format(self.auction_id, self.bid_id),
+    response = self.app.post_json('/auctions/{}/bids/{}/documents?acc_token={}'.format(
+        self.auction_id, self.bid_id, self.bid_token
+    ),
         {'data': {
             'title': 'name.doc',
             'url': self.generate_docservice_url(),
@@ -423,7 +443,9 @@ def create_auction_bidder_document_json(self):
     self.assertEqual(doc_id, response.json["data"]["id"])
     self.assertEqual('name.doc', response.json["data"]["title"])
 
-    response = self.app.post_json('/auctions/{}/bids/{}/documents'.format(self.auction_id, self.bid_id),
+    response = self.app.post_json('/auctions/{}/bids/{}/documents?acc_token={}'.format(
+        self.auction_id, self.bid_id, self.bid_token
+    ),
         {'data': {
             'title': 'name.doc',
             'url': self.generate_docservice_url(),
@@ -437,7 +459,9 @@ def create_auction_bidder_document_json(self):
 
     self.set_status('active.awarded')
 
-    response = self.app.post_json('/auctions/{}/bids/{}/documents'.format(self.auction_id, self.bid_id),
+    response = self.app.post_json('/auctions/{}/bids/{}/documents?acc_token={}'.format(
+        self.auction_id, self.bid_id, self.bid_token
+    ),
         {'data': {
             'title': 'name.doc',
             'url': self.generate_docservice_url(),
@@ -464,7 +488,9 @@ def create_auction_bidder_document_json(self):
 
 
 def put_auction_bidder_document_json(self):
-    response = self.app.post_json('/auctions/{}/bids/{}/documents'.format(self.auction_id, self.bid_id),
+    response = self.app.post_json('/auctions/{}/bids/{}/documents?acc_token={}'.format(
+        self.auction_id, self.bid_id, self.bid_token
+    ),
         {'data': {
             'title': 'name.doc',
             'url': self.generate_docservice_url(),
@@ -476,7 +502,9 @@ def put_auction_bidder_document_json(self):
     doc_id = response.json["data"]['id']
     self.assertIn(doc_id, response.headers['Location'])
 
-    response = self.app.put_json('/auctions/{}/bids/{}/documents/{}'.format(self.auction_id, self.bid_id, doc_id),
+    response = self.app.put_json('/auctions/{}/bids/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, self.bid_id, doc_id, self.bid_token
+    ),
         {'data': {
             'title': 'name.doc',
             'url': self.generate_docservice_url(),
@@ -503,7 +531,9 @@ def put_auction_bidder_document_json(self):
     self.assertEqual(doc_id, response.json["data"]["id"])
     self.assertEqual('name.doc', response.json["data"]["title"])
 
-    response = self.app.put_json('/auctions/{}/bids/{}/documents/{}'.format(self.auction_id, self.bid_id, doc_id),
+    response = self.app.put_json('/auctions/{}/bids/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, self.bid_id, doc_id, self.bid_token
+    ),
         {'data': {
             'title': 'name.doc',
             'url': self.generate_docservice_url(),
@@ -525,7 +555,9 @@ def put_auction_bidder_document_json(self):
 
     self.set_status('active.awarded')
 
-    response = self.app.put_json('/auctions/{}/bids/{}/documents/{}'.format(self.auction_id, self.bid_id, doc_id),
+    response = self.app.put_json('/auctions/{}/bids/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, self.bid_id, doc_id, self.bid_token
+    ),
         {'data': {
             'title': 'name.doc',
             'url': self.generate_docservice_url(),

--- a/openprocurement/auctions/core/tests/blanks/cancellation_blanks.py
+++ b/openprocurement/auctions/core/tests/blanks/cancellation_blanks.py
@@ -12,7 +12,7 @@ def create_auction_cancellation_invalid(self):
         {u'description': u'Not Found', u'location': u'url', u'name': u'auction_id'}
     ])
 
-    request_path = '/auctions/{}/cancellations'.format(self.auction_id)
+    request_path = '/auctions/{}/cancellations?acc_token={}'.format(self.auction_id, self.auction_token)
 
     response = self.app.post(request_path, 'data', status=415)
     self.assertEqual(response.status, '415 Unsupported Media Type')
@@ -70,7 +70,9 @@ def create_auction_cancellation_invalid(self):
             u'body', u'name': u'invalid_field'}
     ])
 
-    response = self.app.post_json('/auctions/{}/cancellations'.format(self.auction_id), {'data': {
+    response = self.app.post_json('/auctions/{}/cancellations?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ), {'data': {
         'reason': 'cancellation reason',
         "cancellationOf": "lot"
     }}, status=422)
@@ -81,7 +83,8 @@ def create_auction_cancellation_invalid(self):
         {u'description': [u'This field is required.'], u'location': u'body', u'name': u'relatedLot'}
     ])
 
-    response = self.app.post_json('/auctions/{}/cancellations'.format(self.auction_id), {'data': {
+    response = self.app.post_json('/auctions/{}/cancellations?acc_token={}'.format(
+        self.auction_id, self.auction_token), {'data': {
         'reason': 'cancellation reason',
         "cancellationOf": "lot",
         "relatedLot": '0' * 32
@@ -95,8 +98,9 @@ def create_auction_cancellation_invalid(self):
 
 
 def create_auction_cancellation(self):
-    response = self.app.post_json('/auctions/{}/cancellations'.format(
-        self.auction_id), {'data': {'reason': 'cancellation reason'}})
+    response = self.app.post_json('/auctions/{}/cancellations?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ), {'data': {'reason': 'cancellation reason'}})
     self.assertEqual(response.status, '201 Created')
     self.assertEqual(response.content_type, 'application/json')
     cancellation = response.json['data']
@@ -109,8 +113,9 @@ def create_auction_cancellation(self):
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['data']["status"], 'active.tendering')
 
-    response = self.app.post_json('/auctions/{}/cancellations'.format(
-        self.auction_id), {'data': {'reason': 'cancellation reason', 'status': 'active'}})
+    response = self.app.post_json('/auctions/{}/cancellations?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ), {'data': {'reason': 'cancellation reason', 'status': 'active'}})
     self.assertEqual(response.status, '201 Created')
     self.assertEqual(response.content_type, 'application/json')
     cancellation = response.json['data']
@@ -125,8 +130,9 @@ def create_auction_cancellation(self):
     self.assertEqual(response.json['data']["status"], 'cancelled')
     self.assertNotIn("bids", response.json['data'])
 
-    response = self.app.post_json('/auctions/{}/cancellations'.format(
-        self.auction_id), {'data': {'reason': 'cancellation reason'}}, status=403)
+    response = self.app.post_json('/auctions/{}/cancellations?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ), {'data': {'reason': 'cancellation reason'}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['errors'][0]["description"],
@@ -134,14 +140,16 @@ def create_auction_cancellation(self):
 
 
 def patch_auction_cancellation(self):
-    response = self.app.post_json('/auctions/{}/cancellations'.format(
-        self.auction_id), {'data': {'reason': 'cancellation reason'}})
+    response = self.app.post_json('/auctions/{}/cancellations?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ), {'data': {'reason': 'cancellation reason'}})
     self.assertEqual(response.status, '201 Created')
     self.assertEqual(response.content_type, 'application/json')
     cancellation = response.json['data']
 
-    response = self.app.patch_json('/auctions/{}/cancellations/{}'.format(self.auction_id, cancellation['id']),
-                                   {"data": {"status": "active"}})
+    response = self.app.patch_json('/auctions/{}/cancellations/{}?acc_token={}'.format(
+        self.auction_id, cancellation['id'], self.auction_token
+    ), {"data": {"status": "active"}})
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['data']["status"], "active")
@@ -152,8 +160,9 @@ def patch_auction_cancellation(self):
     self.assertEqual(response.json['data']["status"], 'cancelled')
     self.assertNotIn("bids", response.json['data'])
 
-    response = self.app.patch_json('/auctions/{}/cancellations/{}'.format(self.auction_id, cancellation['id']),
-                                   {"data": {"status": "pending"}}, status=403)
+    response = self.app.patch_json('/auctions/{}/cancellations/{}?acc_token={}'.format(
+        self.auction_id, cancellation['id'], self.auction_token
+    ), {"data": {"status": "pending"}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['errors'][0]["description"],
@@ -187,8 +196,9 @@ def patch_auction_cancellation(self):
 
 
 def get_auction_cancellation(self):
-    response = self.app.post_json('/auctions/{}/cancellations'.format(
-        self.auction_id), {'data': {'reason': 'cancellation reason'}})
+    response = self.app.post_json('/auctions/{}/cancellations?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ), {'data': {'reason': 'cancellation reason'}})
     self.assertEqual(response.status, '201 Created')
     self.assertEqual(response.content_type, 'application/json')
     cancellation = response.json['data']
@@ -218,8 +228,9 @@ def get_auction_cancellation(self):
 
 
 def get_auction_cancellations(self):
-    response = self.app.post_json('/auctions/{}/cancellations'.format(
-        self.auction_id), {'data': {'reason': 'cancellation reason'}})
+    response = self.app.post_json('/auctions/{}/cancellations?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ), {'data': {'reason': 'cancellation reason'}})
     self.assertEqual(response.status, '201 Created')
     self.assertEqual(response.content_type, 'application/json')
     cancellation = response.json['data']
@@ -243,7 +254,9 @@ def get_auction_cancellations(self):
 
 def create_auction_cancellation_lot(self):
     lot_id = self.initial_lots[0]['id']
-    response = self.app.post_json('/auctions/{}/cancellations'.format(self.auction_id), {'data': {
+    response = self.app.post_json('/auctions/{}/cancellations?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ), {'data': {
         'reason': 'cancellation reason',
         "cancellationOf": "lot",
         "relatedLot": lot_id
@@ -261,7 +274,9 @@ def create_auction_cancellation_lot(self):
     self.assertEqual(response.json['data']['lots'][0]["status"], 'active')
     self.assertEqual(response.json['data']["status"], 'active.tendering')
 
-    response = self.app.post_json('/auctions/{}/cancellations'.format(self.auction_id), {'data': {
+    response = self.app.post_json('/auctions/{}/cancellations?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ), {'data': {
         'reason': 'cancellation reason',
         'status': 'active',
         "cancellationOf": "lot",
@@ -281,8 +296,9 @@ def create_auction_cancellation_lot(self):
     self.assertEqual(response.json['data']['lots'][0]["status"], 'cancelled')
     self.assertEqual(response.json['data']["status"], 'cancelled')
 
-    response = self.app.post_json('/auctions/{}/cancellations'.format(
-        self.auction_id), {'data': {'reason': 'cancellation reason'}}, status=403)
+    response = self.app.post_json('/auctions/{}/cancellations?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ), {'data': {'reason': 'cancellation reason'}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['errors'][0]["description"],
@@ -291,7 +307,9 @@ def create_auction_cancellation_lot(self):
 
 def patch_auction_cancellation_lot(self):
     lot_id = self.initial_lots[0]['id']
-    response = self.app.post_json('/auctions/{}/cancellations'.format(self.auction_id), {'data': {
+    response = self.app.post_json('/auctions/{}/cancellations?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ), {'data': {
         'reason': 'cancellation reason',
         "cancellationOf": "lot",
         "relatedLot": lot_id
@@ -300,7 +318,9 @@ def patch_auction_cancellation_lot(self):
     self.assertEqual(response.content_type, 'application/json')
     cancellation = response.json['data']
 
-    response = self.app.patch_json('/auctions/{}/cancellations/{}'.format(self.auction_id, cancellation['id']),
+    response = self.app.patch_json('/auctions/{}/cancellations/{}?acc_token={}'.format(
+        self.auction_id, cancellation['id'], self.auction_token
+    ),
                                    {"data": {"status": "active"}})
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
@@ -312,8 +332,9 @@ def patch_auction_cancellation_lot(self):
     self.assertEqual(response.json['data']['lots'][0]["status"], 'cancelled')
     self.assertEqual(response.json['data']["status"], 'cancelled')
 
-    response = self.app.patch_json('/auctions/{}/cancellations/{}'.format(self.auction_id, cancellation['id']),
-                                   {"data": {"status": "pending"}}, status=403)
+    response = self.app.patch_json('/auctions/{}/cancellations/{}?acc_token={}'.format(
+        self.auction_id, cancellation['id'], self.auction_token
+    ), {"data": {"status": "pending"}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['errors'][0]["description"],
@@ -330,7 +351,9 @@ def patch_auction_cancellation_lot(self):
 
 def create_auction_cancellation_2_lots(self):
     lot_id = self.initial_lots[0]['id']
-    response = self.app.post_json('/auctions/{}/cancellations'.format(self.auction_id), {'data': {
+    response = self.app.post_json('/auctions/{}/cancellations?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ), {'data': {
         'reason': 'cancellation reason',
         "cancellationOf": "lot",
         "relatedLot": lot_id
@@ -348,7 +371,9 @@ def create_auction_cancellation_2_lots(self):
     self.assertEqual(response.json['data']['lots'][0]["status"], 'active')
     self.assertEqual(response.json['data']["status"], 'active.tendering')
 
-    response = self.app.post_json('/auctions/{}/cancellations'.format(self.auction_id), {'data': {
+    response = self.app.post_json('/auctions/{}/cancellations?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ), {'data': {
         'reason': 'cancellation reason',
         'status': 'active',
         "cancellationOf": "lot",
@@ -368,7 +393,9 @@ def create_auction_cancellation_2_lots(self):
     self.assertEqual(response.json['data']['lots'][0]["status"], 'cancelled')
     self.assertNotEqual(response.json['data']["status"], 'cancelled')
 
-    response = self.app.post_json('/auctions/{}/cancellations'.format(self.auction_id), {'data': {
+    response = self.app.post_json('/auctions/{}/cancellations?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ), {'data': {
         'reason': 'cancellation reason',
         'status': 'active',
         "cancellationOf": "lot",
@@ -381,7 +408,9 @@ def create_auction_cancellation_2_lots(self):
 
 def patch_auction_cancellation_2_lots(self):
     lot_id = self.initial_lots[0]['id']
-    response = self.app.post_json('/auctions/{}/cancellations'.format(self.auction_id), {'data': {
+    response = self.app.post_json('/auctions/{}/cancellations?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ), {'data': {
         'reason': 'cancellation reason',
         "cancellationOf": "lot",
         "relatedLot": lot_id
@@ -390,8 +419,9 @@ def patch_auction_cancellation_2_lots(self):
     self.assertEqual(response.content_type, 'application/json')
     cancellation = response.json['data']
 
-    response = self.app.patch_json('/auctions/{}/cancellations/{}'.format(self.auction_id, cancellation['id']),
-                                   {"data": {"status": "active"}})
+    response = self.app.patch_json('/auctions/{}/cancellations/{}?acc_token={}'.format(
+        self.auction_id, cancellation['id'], self.auction_token
+    ), {"data": {"status": "active"}})
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['data']["status"], "active")
@@ -402,8 +432,9 @@ def patch_auction_cancellation_2_lots(self):
     self.assertEqual(response.json['data']['lots'][0]["status"], 'cancelled')
     self.assertNotEqual(response.json['data']["status"], 'cancelled')
 
-    response = self.app.patch_json('/auctions/{}/cancellations/{}'.format(self.auction_id, cancellation['id']),
-                                   {"data": {"status": "pending"}}, status=403)
+    response = self.app.patch_json('/auctions/{}/cancellations/{}?acc_token={}'.format(
+        self.auction_id, cancellation['id'], self.auction_token
+    ), {"data": {"status": "pending"}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['errors'][0]["description"], "Can update cancellation only in active lot status")
@@ -437,8 +468,9 @@ def not_found(self):
             u'url', u'name': u'cancellation_id'}
     ])
 
-    response = self.app.post('/auctions/{}/cancellations/{}/documents'.format(self.auction_id, self.cancellation_id), status=404, upload_files=[
-                             ('invalid_value', 'name.doc', 'content')])
+    response = self.app.post('/auctions/{}/cancellations/{}/documents?acc_token={}'.format(
+        self.auction_id, self.cancellation_id, self.auction_token
+    ), status=404, upload_files=[('invalid_value', 'name.doc', 'content')])
     self.assertEqual(response.status, '404 Not Found')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['status'], 'error')
@@ -523,8 +555,9 @@ def not_found(self):
 
 
 def create_auction_cancellation_document(self):
-    response = self.app.post('/auctions/{}/cancellations/{}/documents'.format(
-        self.auction_id, self.cancellation_id), upload_files=[('file', 'name.doc', 'content')])
+    response = self.app.post('/auctions/{}/cancellations/{}/documents?acc_token={}'.format(
+        self.auction_id, self.cancellation_id, self.auction_token
+    ), upload_files=[('file', 'name.doc', 'content')])
     self.assertEqual(response.status, '201 Created')
     self.assertEqual(response.content_type, 'application/json')
     doc_id = response.json["data"]['id']
@@ -569,24 +602,26 @@ def create_auction_cancellation_document(self):
 
     self.set_status('complete')
 
-    response = self.app.post('/auctions/{}/cancellations/{}/documents'.format(
-        self.auction_id, self.cancellation_id), upload_files=[('file', 'name.doc', 'content')], status=403)
+    response = self.app.post('/auctions/{}/cancellations/{}/documents?acc_token={}'.format(
+        self.auction_id, self.cancellation_id, self.auction_token
+    ), upload_files=[('file', 'name.doc', 'content')], status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['errors'][0]["description"], "Can't add document in current (complete) auction status")
 
 
 def put_auction_cancellation_document(self):
-    response = self.app.post('/auctions/{}/cancellations/{}/documents'.format(
-        self.auction_id, self.cancellation_id), upload_files=[('file', 'name.doc', 'content')])
+    response = self.app.post('/auctions/{}/cancellations/{}/documents?acc_token={}'.format(
+        self.auction_id, self.cancellation_id, self.auction_token
+    ), upload_files=[('file', 'name.doc', 'content')])
     self.assertEqual(response.status, '201 Created')
     self.assertEqual(response.content_type, 'application/json')
     doc_id = response.json["data"]['id']
     self.assertIn(doc_id, response.headers['Location'])
 
-    response = self.app.put('/auctions/{}/cancellations/{}/documents/{}'.format(self.auction_id, self.cancellation_id, doc_id),
-                            status=404,
-                            upload_files=[('invalid_name', 'name.doc', 'content')])
+    response = self.app.put('/auctions/{}/cancellations/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, self.cancellation_id, doc_id, self.auction_token
+    ), status=404, upload_files=[('invalid_name', 'name.doc', 'content')])
     self.assertEqual(response.status, '404 Not Found')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['status'], 'error')
@@ -595,8 +630,9 @@ def put_auction_cancellation_document(self):
             u'body', u'name': u'file'}
     ])
 
-    response = self.app.put('/auctions/{}/cancellations/{}/documents/{}'.format(
-        self.auction_id, self.cancellation_id, doc_id), upload_files=[('file', 'name.doc', 'content2')])
+    response = self.app.put('/auctions/{}/cancellations/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, self.cancellation_id, doc_id, self.auction_token
+    ), upload_files=[('file', 'name.doc', 'content2')])
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(doc_id, response.json["data"]["id"])
@@ -616,8 +652,9 @@ def put_auction_cancellation_document(self):
     self.assertEqual(doc_id, response.json["data"]["id"])
     self.assertEqual('name.doc', response.json["data"]["title"])
 
-    response = self.app.put('/auctions/{}/cancellations/{}/documents/{}'.format(
-        self.auction_id, self.cancellation_id, doc_id), 'content3', content_type='application/msword')
+    response = self.app.put('/auctions/{}/cancellations/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, self.cancellation_id, doc_id, self.auction_token
+    ), 'content3', content_type='application/msword')
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(doc_id, response.json["data"]["id"])
@@ -632,22 +669,26 @@ def put_auction_cancellation_document(self):
 
     self.set_status('complete')
 
-    response = self.app.put('/auctions/{}/cancellations/{}/documents/{}'.format(
-        self.auction_id, self.cancellation_id, doc_id), upload_files=[('file', 'name.doc', 'content3')], status=403)
+    response = self.app.put('/auctions/{}/cancellations/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, self.cancellation_id, doc_id, self.auction_token
+    ), upload_files=[('file', 'name.doc', 'content3')], status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['errors'][0]["description"], "Can't update document in current (complete) auction status")
 
 
 def patch_auction_cancellation_document(self):
-    response = self.app.post('/auctions/{}/cancellations/{}/documents'.format(
-        self.auction_id, self.cancellation_id), upload_files=[('file', 'name.doc', 'content')])
+    response = self.app.post('/auctions/{}/cancellations/{}/documents?acc_token={}'.format(
+        self.auction_id, self.cancellation_id, self.auction_token
+    ), upload_files=[('file', 'name.doc', 'content')])
     self.assertEqual(response.status, '201 Created')
     self.assertEqual(response.content_type, 'application/json')
     doc_id = response.json["data"]['id']
     self.assertIn(doc_id, response.headers['Location'])
 
-    response = self.app.patch_json('/auctions/{}/cancellations/{}/documents/{}'.format(self.auction_id, self.cancellation_id, doc_id), {"data": {"description": "document description"}})
+    response = self.app.patch_json('/auctions/{}/cancellations/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, self.cancellation_id, doc_id, self.auction_token
+    ), {"data": {"description": "document description"}})
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(doc_id, response.json["data"]["id"])
@@ -661,7 +702,9 @@ def patch_auction_cancellation_document(self):
 
     self.set_status('complete')
 
-    response = self.app.patch_json('/auctions/{}/cancellations/{}/documents/{}'.format(self.auction_id, self.cancellation_id, doc_id), {"data": {"description": "document description"}}, status=403)
+    response = self.app.patch_json('/auctions/{}/cancellations/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, self.cancellation_id, doc_id, self.auction_token
+    ), {"data": {"description": "document description"}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['errors'][0]["description"], "Can't update document in current (complete) auction status")

--- a/openprocurement/auctions/core/tests/blanks/chronograph_blanks.py
+++ b/openprocurement/auctions/core/tests/blanks/chronograph_blanks.py
@@ -53,8 +53,10 @@ def switch_to_pending(self):
 
 def switch_to_complaint(self):
     for status in ['invalid', 'resolved', 'declined']:
-        self.app.authorization = ('Basic', ('token', ''))
-        response = self.app.post_json('/auctions/{}/complaints'.format(self.auction_id), {'data': {
+        self.app.authorization = ('Basic', ('broker', ''))
+        response = self.app.post_json('/auctions/{}/complaints?acc_token={}'.format(
+            self.auction_id, self.auction_token
+        ), {'data': {
             'title': 'complaint title',
             'description': 'complaint description',
             'author': self.initial_organization,
@@ -90,18 +92,21 @@ def switch_to_complaint(self):
 
 
 def switch_to_pending_award(self):
-    response = self.app.post_json('/auctions/{}/awards/{}/complaints'.format(self.auction_id, self.award_id),
-                                  {'data': {
-                                      'title': 'complaint title',
-                                      'description': 'complaint description',
-                                      'author': self.initial_organization,
-                                      'status': 'claim'
-                                  }})
+    response = self.app.post_json('/auctions/{}/awards/{}/complaints?acc_token={}'.format(
+        self.auction_id, self.award_id, self.first_bid_token
+    ),
+      {'data': {
+          'title': 'complaint title',
+          'description': 'complaint description',
+          'author': self.initial_organization,
+          'status': 'claim'
+      }})
     self.assertEqual(response.status, '201 Created')
     self.assertEqual(response.json['data']['status'], 'claim')
 
-    response = self.app.patch_json('/auctions/{}/awards/{}'.format(self.auction_id, self.award_id),
-                                   {"data": {"status": "active"}})
+    response = self.app.patch_json('/auctions/{}/awards/{}?acc_token={}'.format(
+        self.auction_id, self.award_id, self.auction_token
+    ), {"data": {"status": "active"}})
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['data']["status"], "active")
@@ -118,21 +123,24 @@ def switch_to_pending_award(self):
 
 
 def switch_to_complaint_award(self):
-    response = self.app.patch_json('/auctions/{}/awards/{}'.format(self.auction_id, self.award_id),
-                                   {"data": {"status": "active"}})
+    response = self.app.patch_json('/auctions/{}/awards/{}?acc_token={}'.format(
+        self.auction_id, self.award_id, self.auction_token
+    ), {"data": {"status": "active"}})
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['data']["status"], "active")
 
     for status in ['invalid', 'resolved', 'declined']:
-        self.app.authorization = ('Basic', ('token', ''))
-        response = self.app.post_json('/auctions/{}/awards/{}/complaints'.format(self.auction_id, self.award_id),
-                                      {'data': {
-                                          'title': 'complaint title',
-                                          'description': 'complaint description',
-                                          'author': self.initial_organization,
-                                          'status': 'claim'
-                                      }})
+        self.app.authorization = ('Basic', ('broker', ''))
+        response = self.app.post_json('/auctions/{}/awards/{}/complaints?acc_token={}'.format(
+            self.auction_id, self.award_id, self.first_bid_token
+        ),
+          {'data': {
+              'title': 'complaint title',
+              'description': 'complaint description',
+              'author': self.initial_organization,
+              'status': 'claim'
+          }})
         self.assertEqual(response.status, '201 Created')
         self.assertEqual(response.json['data']['status'], 'claim')
         complaint = response.json['data']

--- a/openprocurement/auctions/core/tests/blanks/complaint_blanks.py
+++ b/openprocurement/auctions/core/tests/blanks/complaint_blanks.py
@@ -549,8 +549,9 @@ def not_found(self):
             u'url', u'name': u'complaint_id'}
     ])
 
-    response = self.app.post('/auctions/{}/complaints/{}/documents'.format(self.auction_id, self.complaint_id), status=404, upload_files=[
-                             ('invalid_value', 'name.doc', 'content')])
+    response = self.app.post('/auctions/{}/complaints/{}/documents?acc_token={}'.format(
+        self.auction_id, self.complaint_id, self.auction_token
+    ), status=404, upload_files=[('invalid_value', 'name.doc', 'content')])
     self.assertEqual(response.status, '404 Not Found')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['status'], 'error')
@@ -635,8 +636,9 @@ def not_found(self):
 
 
 def create_auction_complaint_document(self):
-    response = self.app.post('/auctions/{}/complaints/{}/documents'.format(
-        self.auction_id, self.complaint_id), upload_files=[('file', 'name.doc', 'content')], status=403)
+    response = self.app.post('/auctions/{}/complaints/{}/documents?acc_token={}'.format(
+        self.auction_id, self.complaint_id, self.auction_token
+    ), upload_files=[('file', 'name.doc', 'content')], status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['errors'][0]["description"],
@@ -688,8 +690,9 @@ def create_auction_complaint_document(self):
 
     self.set_status('complete')
 
-    response = self.app.post('/auctions/{}/complaints/{}/documents'.format(
-        self.auction_id, self.complaint_id), upload_files=[('file', 'name.doc', 'content')], status=403)
+    response = self.app.post('/auctions/{}/complaints/{}/documents?acc_token={}'.format(
+        self.auction_id, self.complaint_id, self.auction_token
+    ), upload_files=[('file', 'name.doc', 'content')], status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['errors'][0]["description"],
@@ -705,9 +708,9 @@ def put_auction_complaint_document(self):
     self.assertIn(doc_id, response.headers['Location'])
 
     response = self.app.put(
-        '/auctions/{}/complaints/{}/documents/{}'.format(self.auction_id, self.complaint_id, doc_id),
-        status=404,
-        upload_files=[('invalid_name', 'name.doc', 'content')])
+        '/auctions/{}/complaints/{}/documents/{}?acc_token={}'.format(
+            self.auction_id, self.complaint_id, doc_id, self.auction_token
+        ), status=404, upload_files=[('invalid_name', 'name.doc', 'content')])
     self.assertEqual(response.status, '404 Not Found')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['status'], 'error')
@@ -716,8 +719,9 @@ def put_auction_complaint_document(self):
             u'body', u'name': u'file'}
     ])
 
-    response = self.app.put('/auctions/{}/complaints/{}/documents/{}'.format(
-        self.auction_id, self.complaint_id, doc_id), upload_files=[('file', 'name.doc', 'content2')], status=403)
+    response = self.app.put('/auctions/{}/complaints/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, self.complaint_id, doc_id, self.auction_token
+    ), upload_files=[('file', 'name.doc', 'content2')], status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['errors'][0]["description"], "Can update document only author")
@@ -796,8 +800,9 @@ def patch_auction_complaint_document(self):
     self.assertIn(doc_id, response.headers['Location'])
 
     response = self.app.patch_json(
-        '/auctions/{}/complaints/{}/documents/{}'.format(self.auction_id, self.complaint_id, doc_id),
-        {"data": {"description": "document description"}}, status=403)
+        '/auctions/{}/complaints/{}/documents/{}?acc_token={}'.format(
+            self.auction_id, self.complaint_id, doc_id, self.auction_token
+        ), {"data": {"description": "document description"}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['errors'][0]["description"], "Can update document only author")

--- a/openprocurement/auctions/core/tests/blanks/document_blanks.py
+++ b/openprocurement/auctions/core/tests/blanks/document_blanks.py
@@ -26,7 +26,9 @@ def not_found(self):
             u'url', u'name': u'auction_id'}
     ])
 
-    response = self.app.post('/auctions/{}/documents'.format(self.auction_id), status=404, upload_files=[
+    response = self.app.post('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ), status=404, upload_files=[
         ('invalid_name', 'name.doc', 'content')])
     self.assertEqual(response.status, '404 Not Found')
     self.assertEqual(response.content_type, 'application/json')
@@ -81,8 +83,9 @@ def create_auction_document(self):
         self.assertEqual(response.content_type, 'application/json')
         self.assertEqual(len(response.json['data']), 1)
 
-    response = self.app.post('/auctions/{}/documents'.format(
-        self.auction_id), upload_files=[('file', u'укр.doc', 'content')])
+    response = self.app.post('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ), upload_files=[('file', u'укр.doc', 'content')])
     self.assertEqual(response.status, '201 Created')
     self.assertEqual(response.content_type, 'application/json')
     doc_id = response.json["data"]['id']
@@ -148,8 +151,9 @@ def create_auction_document(self):
     self.assertEqual(doc_id, response.json["data"]["id"])
     self.assertEqual(u'укр.doc', response.json["data"]["title"])
 
-    response = self.app.post('/auctions/{}/documents?acc_token=acc_token'.format(
-        self.auction_id), upload_files=[('file', u'укр.doc'.encode("ascii", "xmlcharrefreplace"), 'content')])
+    response = self.app.post('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ), upload_files=[('file', u'укр.doc'.encode("ascii", "xmlcharrefreplace"), 'content')])
     self.assertEqual(response.status, '201 Created')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(u'укр.doc', response.json["data"]["title"])
@@ -159,8 +163,9 @@ def create_auction_document(self):
 
     self.set_status('active.auction')
 
-    response = self.app.post('/auctions/{}/documents'.format(
-        self.auction_id), upload_files=[('file', u'укр.doc', 'content')], status=403)
+    response = self.app.post('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ), upload_files=[('file', u'укр.doc', 'content')], status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['errors'][0]["description"],
@@ -189,8 +194,10 @@ def put_auction_document(self):
     environ = self.app._make_environ()
     environ['CONTENT_TYPE'] = 'multipart/form-data; boundary=BOUNDARY'
     environ['REQUEST_METHOD'] = 'POST'
-    req = self.app.RequestClass.blank(self.app._remove_fragment('/auctions/{}/documents'.format(self.auction_id)),
-                                      environ)
+    req = self.app.RequestClass.blank(
+        self.app._remove_fragment('/auctions/{}/documents?acc_token={}'.format(
+            self.auction_id, self.auction_token
+        )), environ)
     req.environ['wsgi.input'] = BytesIO(body.encode(req.charset or 'utf8'))
     req.content_length = len(body)
     response = self.app.do_request(req)
@@ -204,8 +211,9 @@ def put_auction_document(self):
     datePublished = response.json["data"]['datePublished']
     self.assertIn(doc_id, response.headers['Location'])
 
-    response = self.app.put('/auctions/{}/documents/{}'.format(
-        self.auction_id, doc_id), upload_files=[('file', 'name  name.doc', 'content2')])
+    response = self.app.put('/auctions/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, doc_id, self.auction_token
+    ), upload_files=[('file', 'name  name.doc', 'content2')])
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(doc_id, response.json["data"]["id"])
@@ -255,8 +263,9 @@ def put_auction_document(self):
     self.assertEqual(dateModified, response.json["data"][-2]['dateModified'])
     self.assertEqual(dateModified2, response.json["data"][-1]['dateModified'])
 
-    response = self.app.post('/auctions/{}/documents'.format(
-        self.auction_id), upload_files=[('file', 'name.doc', 'content')])
+    response = self.app.post('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ), upload_files=[('file', 'name.doc', 'content')])
     self.assertEqual(response.status, '201 Created')
     self.assertEqual(response.content_type, 'application/json')
     doc_id = response.json["data"]['id']
@@ -269,7 +278,9 @@ def put_auction_document(self):
     self.assertEqual(dateModified2, response.json["data"][-2]['dateModified'])
     self.assertEqual(dateModified, response.json["data"][-1]['dateModified'])
 
-    response = self.app.put('/auctions/{}/documents/{}'.format(self.auction_id, doc_id), status=404, upload_files=[
+    response = self.app.put('/auctions/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, doc_id, self.auction_token
+    ), status=404, upload_files=[
         ('invalid_name', 'name.doc', 'content')])
     self.assertEqual(response.status, '404 Not Found')
     self.assertEqual(response.content_type, 'application/json')
@@ -279,8 +290,9 @@ def put_auction_document(self):
             u'body', u'name': u'file'}
     ])
 
-    response = self.app.put('/auctions/{}/documents/{}'.format(
-        self.auction_id, doc_id), 'content3', content_type='application/msword')
+    response = self.app.put('/auctions/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, doc_id, self.auction_token
+    ), 'content3', content_type='application/msword')
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(doc_id, response.json["data"]["id"])
@@ -315,8 +327,9 @@ def put_auction_document(self):
 
     self.set_status('active.auction')
 
-    response = self.app.put('/auctions/{}/documents/{}'.format(
-        self.auction_id, doc_id), upload_files=[('file', 'name.doc', 'content3')], status=403)
+    response = self.app.put('/auctions/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, doc_id, self.auction_token
+    ), upload_files=[('file', 'name.doc', 'content3')], status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['errors'][0]["description"],
@@ -334,7 +347,9 @@ def patch_auction_document(self):
         self.assertEqual('x_dgfPlatformLegalDetails', response.json["data"][0]["documentType"])
         doc_id = response.json["data"][0]['id']
 
-        response = self.app.patch_json('/auctions/{}/documents/{}'.format(self.auction_id, doc_id), {"data": {
+        response = self.app.patch_json('/auctions/{}/documents/{}?acc_token={}'.format(
+            self.auction_id, doc_id, self.auction_token
+        ), {"data": {
             'format': 'application/msword',
             "documentType": 'auctionNotice'
         }}, status=422)
@@ -346,8 +361,9 @@ def patch_auction_document(self):
              u'location': u'body', u'name': u'documents'}
         ])
 
-    response = self.app.post('/auctions/{}/documents'.format(
-        self.auction_id), upload_files=[('file', str(Header(u'укр.doc', 'utf-8')), 'content')])
+    response = self.app.post('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ), upload_files=[('file', str(Header(u'укр.doc', 'utf-8')), 'content')])
     self.assertEqual(response.status, '201 Created')
     self.assertEqual(response.content_type, 'application/json')
     doc_id = response.json["data"]['id']
@@ -356,7 +372,9 @@ def patch_auction_document(self):
     self.assertEqual(u'укр.doc', response.json["data"]["title"])
     self.assertNotIn("documentType", response.json["data"])
 
-    response = self.app.patch_json('/auctions/{}/documents/{}'.format(self.auction_id, doc_id), {"data": {
+    response = self.app.patch_json('/auctions/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, doc_id, self.auction_token
+    ), {"data": {
         "documentOf": "lot"
     }}, status=422)
     self.assertEqual(response.status, '422 Unprocessable Entity')
@@ -366,7 +384,9 @@ def patch_auction_document(self):
         {u'description': [u'This field is required.'], u'location': u'body', u'name': u'relatedItem'},
     ])
 
-    response = self.app.patch_json('/auctions/{}/documents/{}'.format(self.auction_id, doc_id), {"data": {
+    response = self.app.patch_json('/auctions/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, doc_id, self.auction_token
+    ), {"data": {
         "documentOf": "lot",
         "relatedItem": '0' * 32
     }}, status=422)
@@ -377,7 +397,9 @@ def patch_auction_document(self):
         {u'description': [u'relatedItem should be one of lots'], u'location': u'body', u'name': u'relatedItem'}
     ])
 
-    response = self.app.patch_json('/auctions/{}/documents/{}'.format(self.auction_id, doc_id), {"data": {
+    response = self.app.patch_json('/auctions/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, doc_id, self.auction_token
+    ), {"data": {
         "documentOf": "item",
         "relatedItem": '0' * 32
     }}, status=422)
@@ -388,7 +410,9 @@ def patch_auction_document(self):
         {u'description': [u'relatedItem should be one of items'], u'location': u'body', u'name': u'relatedItem'}
     ])
 
-    response = self.app.patch_json('/auctions/{}/documents/{}'.format(self.auction_id, doc_id), {"data": {
+    response = self.app.patch_json('/auctions/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, doc_id, self.auction_token
+    ), {"data": {
         "description": "document description",
         "documentType": 'auctionNotice'
     }})
@@ -398,7 +422,9 @@ def patch_auction_document(self):
     self.assertIn("documentType", response.json["data"])
     self.assertEqual(response.json["data"]["documentType"], 'auctionNotice')
 
-    response = self.app.patch_json('/auctions/{}/documents/{}'.format(self.auction_id, doc_id), {"data": {
+    response = self.app.patch_json('/auctions/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, doc_id, self.auction_token
+    ), {"data": {
         "documentType": None
     }})
     self.assertEqual(response.status, '200 OK')
@@ -415,8 +441,9 @@ def patch_auction_document(self):
 
     self.set_status('active.auction')
 
-    response = self.app.patch_json('/auctions/{}/documents/{}'.format(self.auction_id, doc_id),
-                                   {"data": {"description": "document description"}}, status=403)
+    response = self.app.patch_json('/auctions/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, doc_id, self.auction_token
+    ), {"data": {"description": "document description"}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['errors'][0]["description"],
@@ -426,7 +453,9 @@ def patch_auction_document(self):
 
 
 def create_auction_document_json_invalid(self):
-    response = self.app.post_json('/auctions/{}/documents'.format(self.auction_id),
+    response = self.app.post_json('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ),
         {'data': {
             'title': u'укр.doc',
             'url': self.generate_docservice_url(),
@@ -436,7 +465,9 @@ def create_auction_document_json_invalid(self):
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['errors'][0]["description"], "This field is required.")
 
-    response = self.app.post_json('/auctions/{}/documents'.format(self.auction_id),
+    response = self.app.post_json('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ),
         {'data': {
             'title': u'укр.doc',
             'url': self.generate_docservice_url(),
@@ -449,7 +480,9 @@ def create_auction_document_json_invalid(self):
         {u'description': [u'Hash type is not supported.'], u'location': u'body', u'name': u'hash'}
     ])
 
-    response = self.app.post_json('/auctions/{}/documents'.format(self.auction_id),
+    response = self.app.post_json('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ),
         {'data': {
             'title': u'укр.doc',
             'url': self.generate_docservice_url(),
@@ -462,7 +495,9 @@ def create_auction_document_json_invalid(self):
         {u'description': [u'Hash type is not supported.'], u'location': u'body', u'name': u'hash'}
     ])
 
-    response = self.app.post_json('/auctions/{}/documents'.format(self.auction_id),
+    response = self.app.post_json('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ),
         {'data': {
             'title': u'укр.doc',
             'url': self.generate_docservice_url(),
@@ -475,7 +510,9 @@ def create_auction_document_json_invalid(self):
         {u'description': [u'Hash value is wrong length.'], u'location': u'body', u'name': u'hash'}
     ])
 
-    response = self.app.post_json('/auctions/{}/documents'.format(self.auction_id),
+    response = self.app.post_json('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ),
         {'data': {
             'title': u'укр.doc',
             'url': self.generate_docservice_url(),
@@ -488,7 +525,9 @@ def create_auction_document_json_invalid(self):
         {u'description': [u'Hash value is not hexadecimal.'], u'location': u'body', u'name': u'hash'}
     ])
 
-    response = self.app.post_json('/auctions/{}/documents'.format(self.auction_id),
+    response = self.app.post_json('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ),
         {'data': {
             'title': u'укр.doc',
             'url': 'http://invalid.docservice.url/get/uuid',
@@ -499,7 +538,9 @@ def create_auction_document_json_invalid(self):
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['errors'][0]["description"], "Can add document only from document service.")
 
-    response = self.app.post_json('/auctions/{}/documents'.format(self.auction_id),
+    response = self.app.post_json('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ),
         {'data': {
             'title': u'укр.doc',
             'url': '/'.join(self.generate_docservice_url().split('/')[:4]),
@@ -510,7 +551,9 @@ def create_auction_document_json_invalid(self):
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['errors'][0]["description"], "Can add document only from document service.")
 
-    response = self.app.post_json('/auctions/{}/documents'.format(self.auction_id),
+    response = self.app.post_json('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ),
         {'data': {
             'title': u'укр.doc',
             'url': self.generate_docservice_url().split('?')[0],
@@ -521,7 +564,9 @@ def create_auction_document_json_invalid(self):
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['errors'][0]["description"], "Can add document only from document service.")
 
-    response = self.app.post_json('/auctions/{}/documents'.format(self.auction_id),
+    response = self.app.post_json('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ),
         {'data': {
             'title': u'укр.doc',
             'url': self.generate_docservice_url().replace(self.app.app.registry.keyring.keys()[-1], '0' * 8),
@@ -532,7 +577,9 @@ def create_auction_document_json_invalid(self):
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['errors'][0]["description"], "Document url expired.")
 
-    response = self.app.post_json('/auctions/{}/documents'.format(self.auction_id),
+    response = self.app.post_json('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ),
         {'data': {
             'title': u'укр.doc',
             'url': self.generate_docservice_url().replace("Signature=", "Signature=ABC"),
@@ -543,7 +590,9 @@ def create_auction_document_json_invalid(self):
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['errors'][0]["description"], "Document url signature invalid.")
 
-    response = self.app.post_json('/auctions/{}/documents'.format(self.auction_id),
+    response = self.app.post_json('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ),
         {'data': {
             'title': u'укр.doc',
             'url': self.generate_docservice_url().replace("Signature=", "Signature=bw%3D%3D"),
@@ -556,7 +605,9 @@ def create_auction_document_json_invalid(self):
 
 
 def create_auction_document_json(self):
-    response = self.app.post_json('/auctions/{}/documents'.format(self.auction_id),
+    response = self.app.post_json('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ),
         {'data': {
             'title': u'укр.doc',
             'url': self.generate_docservice_url(),
@@ -610,7 +661,9 @@ def create_auction_document_json(self):
 
     self.set_status('active.auction')
 
-    response = self.app.post_json('/auctions/{}/documents'.format(self.auction_id),
+    response = self.app.post_json('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ),
         {'data': {
             'title': u'укр.doc',
             'url': self.generate_docservice_url(),
@@ -623,7 +676,9 @@ def create_auction_document_json(self):
 
 
 def put_auction_document_json(self):
-    response = self.app.post_json('/auctions/{}/documents'.format(self.auction_id),
+    response = self.app.post_json('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ),
         {'data': {
             'title': u'укр.doc',
             'url': self.generate_docservice_url(),
@@ -638,7 +693,9 @@ def put_auction_document_json(self):
     datePublished = response.json["data"]['datePublished']
     self.assertIn(doc_id, response.headers['Location'])
 
-    response = self.app.put_json('/auctions/{}/documents/{}'.format(self.auction_id, doc_id),
+    response = self.app.put_json('/auctions/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, doc_id, self.auction_token
+    ),
         {'data': {
             'title': u'name.doc',
             'url': self.generate_docservice_url(),
@@ -683,7 +740,9 @@ def put_auction_document_json(self):
     self.assertEqual(dateModified, response.json["data"][-2]['dateModified'])
     self.assertEqual(dateModified2, response.json["data"][-1]['dateModified'])
 
-    response = self.app.post_json('/auctions/{}/documents'.format(self.auction_id),
+    response = self.app.post_json('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ),
         {'data': {
             'title': 'name.doc',
             'url': self.generate_docservice_url(),
@@ -702,7 +761,9 @@ def put_auction_document_json(self):
     self.assertEqual(dateModified2, response.json["data"][-2]['dateModified'])
     self.assertEqual(dateModified, response.json["data"][-1]['dateModified'])
 
-    response = self.app.put_json('/auctions/{}/documents/{}'.format(self.auction_id, doc_id),
+    response = self.app.put_json('/auctions/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, doc_id, self.auction_token
+    ),
         {'data': {
             'title': u'укр.doc',
             'url': self.generate_docservice_url(),
@@ -732,7 +793,9 @@ def put_auction_document_json(self):
 
     self.set_status('active.auction')
 
-    response = self.app.put_json('/auctions/{}/documents/{}'.format(self.auction_id, doc_id),
+    response = self.app.put_json('/auctions/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, doc_id, self.auction_token
+    ),
         {'data': {
             'title': u'укр.doc',
             'url': self.generate_docservice_url(),
@@ -746,12 +809,13 @@ def put_auction_document_json(self):
 
 def create_auction_document_pas(self):
     pas_url = 'http://torgi.fg.gov.ua/id_of_lot'
-    response = self.app.post_json('/auctions/{}/documents'.format(self.auction_id),
-                                  {'data': {
-                                      'title': u'PAS for auction lot',
-                                      'url': pas_url,
-                                      'documentType': 'x_dgfPublicAssetCertificate',
-                                  }})
+    response = self.app.post_json('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ),  {'data': {
+            'title': u'PAS for auction lot',
+            'url': pas_url,
+            'documentType': 'x_dgfPublicAssetCertificate',
+        }})
     self.assertEqual(response.status, '201 Created')
     self.assertEqual(response.content_type, 'application/json')
     doc_id = response.json["data"]['id']
@@ -789,12 +853,13 @@ def create_auction_document_pas(self):
 
     self.set_status('active.auction')
 
-    response = self.app.post_json('/auctions/{}/documents'.format(self.auction_id),
-                                  {'data': {
-                                      'title': u'PAS for auction lot',
-                                      'url': pas_url,
-                                      'documentType': 'x_dgfPublicAssetCertificate',
-                                  }}, status=403)
+    response = self.app.post_json('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ), {'data': {
+            'title': u'PAS for auction lot',
+            'url': pas_url,
+            'documentType': 'x_dgfPublicAssetCertificate',
+      }}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['errors'][0]["description"],
@@ -803,8 +868,9 @@ def create_auction_document_pas(self):
 
 def put_auction_document_pas(self):
     pas_url = 'http://torgi.fg.gov.ua/id_of_lot'
-    response = self.app.post_json('/auctions/{}/documents'.format(self.auction_id),
-        {'data': {
+    response = self.app.post_json('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ), {'data': {
             'title': u'PAS for auction lot',
             'url': pas_url,
             'documentType': 'x_dgfPublicAssetCertificate',
@@ -820,7 +886,9 @@ def put_auction_document_pas(self):
     datePublished = response.json["data"]['datePublished']
     self.assertIn(doc_id, response.headers['Location'])
 
-    response = self.app.put_json('/auctions/{}/documents/{}'.format(self.auction_id, doc_id),
+    response = self.app.put_json('/auctions/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, doc_id, self.auction_token
+    ),
         {'data': {
             'title': u'name.doc',
             'url': self.generate_docservice_url(),
@@ -831,7 +899,9 @@ def put_auction_document_pas(self):
         {u'description': [u'This field is required.'], u'location': u'body', u'name': u'format'}
     ])
 
-    response = self.app.put_json('/auctions/{}/documents/{}'.format(self.auction_id, doc_id),
+    response = self.app.put_json('/auctions/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, doc_id, self.auction_token
+    ),
         {'data': {
             'title': u'name.doc',
             'url': self.generate_docservice_url(),
@@ -845,7 +915,9 @@ def put_auction_document_pas(self):
     ])
 
     pas_url = 'http://torgi.fg.gov.ua/new_id_of_lot'
-    response = self.app.put_json('/auctions/{}/documents/{}'.format(self.auction_id, doc_id),
+    response = self.app.put_json('/auctions/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, doc_id, self.auction_token
+    ),
         {'data': {
             'title': u'PAS for auction lot #2',
             'url': pas_url,
@@ -893,7 +965,9 @@ def put_auction_document_pas(self):
     self.assertEqual(dateModified2, response.json["data"][-1]['dateModified'])
 
     pas_url = 'http://torgi.fg.gov.ua/new_new_id_of_lot'
-    response = self.app.post_json('/auctions/{}/documents'.format(self.auction_id),
+    response = self.app.post_json('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ),
         {'data': {
             'title': u'PAS for auction lot #3',
             'url': pas_url,
@@ -912,7 +986,9 @@ def put_auction_document_pas(self):
     self.assertEqual(dateModified, response.json["data"][-1]['dateModified'])
 
     pas_url = 'http://torgi.fg.gov.ua/new_new_new_id_of_lot'
-    response = self.app.put_json('/auctions/{}/documents/{}'.format(self.auction_id, doc_id),
+    response = self.app.put_json('/auctions/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, doc_id, self.auction_token
+    ),
         {'data': {
             'title': u'PAS for auction lot #4',
             'url': pas_url,
@@ -937,7 +1013,9 @@ def put_auction_document_pas(self):
 
     self.set_status('active.auction')
 
-    response = self.app.put_json('/auctions/{}/documents/{}'.format(self.auction_id, doc_id),
+    response = self.app.put_json('/auctions/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, doc_id, self.auction_token
+    ),
         {'data': {
             'title': u'PAS for auction lot #5',
             'url': pas_url,
@@ -949,7 +1027,9 @@ def put_auction_document_pas(self):
 
 
 def create_auction_offline_document(self):
-    response = self.app.post_json('/auctions/{}/documents'.format(self.auction_id),
+    response = self.app.post_json('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ),
         {'data': {
             'title': u'Порядок ознайомлення з майном / Порядок ознайомлення з активом у кімнаті даних',
             'documentType': 'x_dgfAssetFamiliarization',
@@ -992,7 +1072,9 @@ def create_auction_offline_document(self):
 
     self.set_status('active.auction')
 
-    response = self.app.post_json('/auctions/{}/documents'.format(self.auction_id),
+    response = self.app.post_json('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ),
         {'data': {
             'title': u'Порядок ознайомлення з майном / Порядок ознайомлення з активом у кімнаті даних',
             'documentType': 'x_dgfAssetFamiliarization',
@@ -1005,7 +1087,9 @@ def create_auction_offline_document(self):
 
 def put_auction_offline_document(self):
     response = self.app.get('/auctions/{}/documents'.format(self.auction_id))
-    response = self.app.post_json('/auctions/{}/documents'.format(self.auction_id),
+    response = self.app.post_json('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ),
         {'data': {
             'title': u'Порядок ознайомлення з майном / Порядок ознайомлення з активом у кімнаті даних',
             'documentType': 'x_dgfAssetFamiliarization',
@@ -1022,7 +1106,9 @@ def put_auction_offline_document(self):
     dateModified = response.json["data"]['dateModified']
     datePublished = response.json["data"]['datePublished']
 
-    response = self.app.put_json('/auctions/{}/documents/{}'.format(self.auction_id, doc_id),
+    response = self.app.put_json('/auctions/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, doc_id, self.auction_token
+    ),
         {'data': {
             'title': u'Новий порядок ознайомлення',
             'documentType': 'x_dgfAssetFamiliarization',
@@ -1033,7 +1119,9 @@ def put_auction_offline_document(self):
         {u'description': [u'This field is required.'], u'location': u'body', u'name': u'accessDetails'}
     ])
 
-    response = self.app.put_json('/auctions/{}/documents/{}'.format(self.auction_id, doc_id),
+    response = self.app.put_json('/auctions/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, doc_id, self.auction_token
+    ),
         {'data': {
             'title': u'Новий порядок ознайомлення',
             'documentType': 'x_dgfAssetFamiliarization',
@@ -1044,7 +1132,9 @@ def put_auction_offline_document(self):
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['errors'], [{'description': [u'This field is not required.'], u'location': u'body', u'name': u'hash'}])
 
-    response = self.app.put_json('/auctions/{}/documents/{}'.format(self.auction_id, doc_id),
+    response = self.app.put_json('/auctions/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, doc_id, self.auction_token
+    ),
         {'data': {
             'title': u'Порядок ознайомлення з майном #2',
             'documentType': 'x_dgfAssetFamiliarization',
@@ -1089,7 +1179,9 @@ def put_auction_offline_document(self):
     self.assertEqual(dateModified, response.json["data"][-2]['dateModified'])
     self.assertEqual(dateModified2, response.json["data"][-1]['dateModified'])
 
-    response = self.app.post_json('/auctions/{}/documents'.format(self.auction_id),
+    response = self.app.post_json('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ),
         {'data': {
             'title': u'Порядок ознайомлення з майном #3',
             'documentType': 'x_dgfAssetFamiliarization',
@@ -1107,7 +1199,9 @@ def put_auction_offline_document(self):
     self.assertEqual(dateModified2, response.json["data"][-2]['dateModified'])
     self.assertEqual(dateModified, response.json["data"][-1]['dateModified'])
 
-    response = self.app.put_json('/auctions/{}/documents/{}'.format(self.auction_id, doc_id),
+    response = self.app.put_json('/auctions/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, doc_id, self.auction_token
+    ),
         {'data': {
             'title': u'Порядок ознайомлення з майном #4',
             'documentType': 'x_dgfAssetFamiliarization',
@@ -1125,7 +1219,9 @@ def put_auction_offline_document(self):
 
     self.set_status('active.auction')
 
-    response = self.app.put_json('/auctions/{}/documents/{}'.format(self.auction_id, doc_id),
+    response = self.app.put_json('/auctions/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, doc_id, self.auction_token
+    ),
         {'data': {
             'title': u'Порядок ознайомлення з майном #5',
             'documentType': 'x_dgfAssetFamiliarization',
@@ -1138,7 +1234,9 @@ def put_auction_offline_document(self):
 
 def create_auction_document_vdr(self):
     vdr_url = 'http://virtial-data-room.com/id_of_room'
-    response = self.app.post_json('/auctions/{}/documents'.format(self.auction_id),
+    response = self.app.post_json('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ),
         {'data': {
             'title': u'VDR for auction lot',
             'url': vdr_url,
@@ -1181,7 +1279,9 @@ def create_auction_document_vdr(self):
 
     self.set_status('active.auction')
 
-    response = self.app.post_json('/auctions/{}/documents'.format(self.auction_id),
+    response = self.app.post_json('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ),
         {'data': {
             'title': u'VDR for auction lot',
             'url': vdr_url,
@@ -1194,7 +1294,9 @@ def create_auction_document_vdr(self):
 
 def put_auction_document_vdr(self):
     vdr_url = 'http://virtial-data-room.com/id_of_room'
-    response = self.app.post_json('/auctions/{}/documents'.format(self.auction_id),
+    response = self.app.post_json('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ),
         {'data': {
             'title': u'VDR for auction lot',
             'url': vdr_url,
@@ -1211,7 +1313,9 @@ def put_auction_document_vdr(self):
     datePublished = response.json["data"]['datePublished']
     self.assertIn(doc_id, response.headers['Location'])
 
-    response = self.app.put_json('/auctions/{}/documents/{}'.format(self.auction_id, doc_id),
+    response = self.app.put_json('/auctions/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, doc_id, self.auction_token
+    ),
         {'data': {
             'title': u'name.doc',
             'url': self.generate_docservice_url(),
@@ -1222,7 +1326,9 @@ def put_auction_document_vdr(self):
         {u'description': [u'This field is required.'], u'location': u'body', u'name': u'format'}
     ])
 
-    response = self.app.put_json('/auctions/{}/documents/{}'.format(self.auction_id, doc_id),
+    response = self.app.put_json('/auctions/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, doc_id, self.auction_token
+    ),
         {'data': {
             'title': u'name.doc',
             'url': self.generate_docservice_url(),
@@ -1236,7 +1342,9 @@ def put_auction_document_vdr(self):
     ])
 
     vdr_url = 'http://virtial-data-room.com/new_id_of_room'
-    response = self.app.put_json('/auctions/{}/documents/{}'.format(self.auction_id, doc_id),
+    response = self.app.put_json('/auctions/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, doc_id, self.auction_token
+    ),
         {'data': {
             'title': u'VDR for auction lot #2',
             'url': vdr_url,
@@ -1284,7 +1392,9 @@ def put_auction_document_vdr(self):
     self.assertEqual(dateModified2, response.json["data"][-1]['dateModified'])
 
     vdr_url = 'http://virtial-data-room.com/new_new_id_of_room'
-    response = self.app.post_json('/auctions/{}/documents'.format(self.auction_id),
+    response = self.app.post_json('/auctions/{}/documents?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ),
         {'data': {
             'title': u'VDR for auction lot #3',
             'url': vdr_url,
@@ -1303,7 +1413,9 @@ def put_auction_document_vdr(self):
     self.assertEqual(dateModified, response.json["data"][-1]['dateModified'])
 
     vdr_url = 'http://virtial-data-room.com/new_new_new_id_of_room'
-    response = self.app.put_json('/auctions/{}/documents/{}'.format(self.auction_id, doc_id),
+    response = self.app.put_json('/auctions/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, doc_id, self.auction_token
+    ),
         {'data': {
             'title': u'VDR for auction lot #4',
             'url': vdr_url,
@@ -1328,7 +1440,9 @@ def put_auction_document_vdr(self):
 
     self.set_status('active.auction')
 
-    response = self.app.put_json('/auctions/{}/documents/{}'.format(self.auction_id, doc_id),
+    response = self.app.put_json('/auctions/{}/documents/{}?acc_token={}'.format(
+        self.auction_id, doc_id, self.auction_token
+    ),
         {'data': {
             'title': u'VDR for auction lot #5',
             'url': vdr_url,

--- a/openprocurement/auctions/core/tests/blanks/question_blanks.py
+++ b/openprocurement/auctions/core/tests/blanks/question_blanks.py
@@ -183,8 +183,9 @@ def patch_auction_question(self):
     self.assertEqual(response.content_type, 'application/json')
     question = response.json['data']
 
-    response = self.app.patch_json('/auctions/{}/questions/{}'.format(self.auction_id, question['id']),
-                                   {"data": {"answer": "answer"}})
+    response = self.app.patch_json('/auctions/{}/questions/{}?acc_token={}'.format(
+        self.auction_id, question['id'], self.auction_token
+    ), {"data": {"answer": "answer"}})
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['data']["answer"], "answer")
@@ -215,8 +216,9 @@ def patch_auction_question(self):
 
     self.set_status('active.auction')
 
-    response = self.app.patch_json('/auctions/{}/questions/{}'.format(self.auction_id, question['id']),
-                                   {"data": {"answer": "answer"}}, status=403)
+    response = self.app.patch_json('/auctions/{}/questions/{}?acc_token={}'.format(
+        self.auction_id, question['id'], self.auction_token
+    ), {"data": {"answer": "answer"}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['errors'][0]["description"],
@@ -295,7 +297,9 @@ def get_auction_questions(self):
 
 
 def create_auction_question_lot(self):
-    response = self.app.post_json('/auctions/{}/cancellations'.format(self.auction_id), {'data': {
+    response = self.app.post_json('/auctions/{}/cancellations?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ), {'data': {
         'reason': 'cancellation reason',
         'status': 'active',
         "cancellationOf": "lot",
@@ -303,7 +307,9 @@ def create_auction_question_lot(self):
     }})
     self.assertEqual(response.status, '201 Created')
 
-    response = self.app.post_json('/auctions/{}/questions'.format(self.auction_id), {'data': {
+    response = self.app.post_json('/auctions/{}/questions?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ), {'data': {
         'title': 'question title',
         'description': 'question description',
         "questionOf": "lot",
@@ -314,7 +320,9 @@ def create_auction_question_lot(self):
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['errors'][0]["description"], "Can add question only in active lot status")
 
-    response = self.app.post_json('/auctions/{}/questions'.format(self.auction_id), {'data': {
+    response = self.app.post_json('/auctions/{}/questions?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ), {'data': {
         'title': 'question title',
         'description': 'question description',
         "questionOf": "lot",
@@ -341,7 +349,9 @@ def patch_auction_question_lot(self):
     self.assertEqual(response.content_type, 'application/json')
     question = response.json['data']
 
-    response = self.app.post_json('/auctions/{}/cancellations'.format(self.auction_id), {'data': {
+    response = self.app.post_json('/auctions/{}/cancellations?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ), {'data': {
         'reason': 'cancellation reason',
         'status': 'active',
         "cancellationOf": "lot",
@@ -349,13 +359,16 @@ def patch_auction_question_lot(self):
     }})
     self.assertEqual(response.status, '201 Created')
 
-    response = self.app.patch_json('/auctions/{}/questions/{}'.format(self.auction_id, question['id']),
-                                   {"data": {"answer": "answer"}}, status=403)
+    response = self.app.patch_json('/auctions/{}/questions/{}?acc_token={}'.format(
+        self.auction_id, question['id'], self.auction_token
+    ), {"data": {"answer": "answer"}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['errors'][0]["description"], "Can update question only in active lot status")
 
-    response = self.app.post_json('/auctions/{}/questions'.format(self.auction_id), {'data': {
+    response = self.app.post_json('/auctions/{}/questions?acc_token={}'.format(
+        self.auction_id, self.auction_token
+    ), {'data': {
         'title': 'question title',
         'description': 'question description',
         "questionOf": "lot",
@@ -366,8 +379,9 @@ def patch_auction_question_lot(self):
     self.assertEqual(response.content_type, 'application/json')
     question = response.json['data']
 
-    response = self.app.patch_json('/auctions/{}/questions/{}'.format(self.auction_id, question['id']),
-                                   {"data": {"answer": "answer"}})
+    response = self.app.patch_json('/auctions/{}/questions/{}?acc_token={}'.format(
+        self.auction_id, question['id'], self.auction_token
+    ), {"data": {"answer": "answer"}})
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['data']["answer"], "answer")

--- a/openprocurement/auctions/core/tests/lot.py
+++ b/openprocurement/auctions/core/tests/lot.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import unittest
+
 from openprocurement.auctions.core.tests.base import snitch
 from openprocurement.auctions.core.tests.blanks.lot_blanks import (
     # AuctionLotResourceTest
@@ -37,7 +39,7 @@ class AuctionLotResourceTestMixin(object):
 
     test_get_auction_lots = snitch(get_auction_lots)
     test_delete_auction_lot = snitch(delete_auction_lot)
-    test_auction_lot_guarantee = snitch(auction_lot_guarantee)
+    # test_auction_lot_guarantee = snitch(auction_lot_guarantee)
 
 
 class AuctionLotProcessTestMixin(object):

--- a/openprocurement/auctions/core/tests/plugins/awarding/v3/tests/award.py
+++ b/openprocurement/auctions/core/tests/plugins/awarding/v3/tests/award.py
@@ -1,3 +1,5 @@
+import unittest
+
 from openprocurement.auctions.core.tests.base import snitch
 from openprocurement.auctions.core.plugins.awarding.v3.tests.blanks.award_blanks import (
     # AuctionAwardProcessTest
@@ -69,8 +71,12 @@ class AuctionAwardProcessTestMixin(object):
 
 
 class CreateAuctionAwardTestMixin(object):
-    test_create_auction_award_invalid = snitch(create_auction_award_invalid)
-    test_create_auction_award = snitch(create_auction_award)
+    test_create_auction_award_invalid = unittest.skip('option not available')(
+        snitch(create_auction_award_invalid)
+    )
+    test_create_auction_award = unittest.skip('option not available')(
+        snitch(create_auction_award)
+    )
     test_award_activation_creates_contract = snitch(
         award_activation_creates_contract
     )

--- a/openprocurement/auctions/core/tests/plugins/awarding/v3/tests/blanks/chronograph_blanks.py
+++ b/openprocurement/auctions/core/tests/plugins/awarding/v3/tests/blanks/chronograph_blanks.py
@@ -36,8 +36,9 @@ def switch_active_to_unsuccessful(self):
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json["data"]["documentType"], 'auctionProtocol')
 
-    response = self.app.patch_json('/auctions/{}/awards/{}'.format(self.auction_id, self.award_id),
-                                   {"data": {"status": "active"}})
+    response = self.app.patch_json('/auctions/{}/awards/{}?acc_token={}'.format(
+        self.auction_id, self.award_id, self.auction_token
+    ), {"data": {"status": "active"}})
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['data']["status"], "active")
@@ -107,8 +108,9 @@ def switch_suspended_active_to_unsuccessful(self):
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json["data"]["documentType"], 'auctionProtocol')
 
-    response = self.app.patch_json('/auctions/{}/awards/{}'.format(self.auction_id, self.award_id),
-                                   {"data": {"status": "active"}})
+    response = self.app.patch_json('/auctions/{}/awards/{}?acc_token={}'.format(
+        self.auction_id, self.award_id, self.auction_token
+    ), {"data": {"status": "active"}})
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['data']["status"], "active")
@@ -183,8 +185,9 @@ def switch_active_to_unsuccessful_2(self):
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json["data"]["documentType"], 'auctionProtocol')
 
-    response = self.app.patch_json('/auctions/{}/awards/{}'.format(self.auction_id, self.award_id),
-                                   {"data": {"status": "active"}})
+    response = self.app.patch_json('/auctions/{}/awards/{}?acc_token={}'.format(
+        self.auction_id, self.award_id, self.auction_token
+    ), {"data": {"status": "active"}})
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['data']["status"], "active")

--- a/openprocurement/auctions/core/tests/plugins/awarding/v3_1/tests/award.py
+++ b/openprocurement/auctions/core/tests/plugins/awarding/v3_1/tests/award.py
@@ -1,3 +1,5 @@
+import unittest
+
 from openprocurement.auctions.core.tests.base import snitch
 from blanks.award_blanks import (
     # AuctionAwardProcessTest
@@ -69,8 +71,12 @@ class AuctionAwardProcessTestMixin(object):
 
 
 class CreateAuctionAwardTestMixin(object):
-    test_create_auction_award_invalid = snitch(create_auction_award_invalid)
-    test_create_auction_award = snitch(create_auction_award)
+    test_create_auction_award_invalid = unittest.skip('option not available')(
+        snitch(create_auction_award_invalid)
+    )
+    test_create_auction_award = unittest.skip('option not available')(
+        snitch(create_auction_award)
+    )
     test_award_activation_creates_contract = snitch(
         award_activation_creates_contract
     )

--- a/openprocurement/auctions/core/tests/plugins/awarding/v3_1/tests/blanks/chronograph_blanks.py
+++ b/openprocurement/auctions/core/tests/plugins/awarding/v3_1/tests/blanks/chronograph_blanks.py
@@ -36,8 +36,9 @@ def not_switch_active_to_unsuccessful(self):
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json["data"]["documentType"], 'auctionProtocol')
 
-    response = self.app.patch_json('/auctions/{}/awards/{}'.format(self.auction_id, self.award_id),
-                                   {"data": {"status": "active"}})
+    response = self.app.patch_json('/auctions/{}/awards/{}?acc_token={}'.format(
+        self.auction_id, self.award_id, self.auction_token
+    ), {"data": {"status": "active"}})
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['data']["status"], "active")

--- a/openprocurement/auctions/core/tests/plugins/contracting/v1/tests/blanks/contract_blanks.py
+++ b/openprocurement/auctions/core/tests/plugins/contracting/v1/tests/blanks/contract_blanks.py
@@ -68,17 +68,11 @@ def create_auction_contract_in_complete_status(self):
 
 
 def get_auction_contract(self):
-    response = self.app.post_json('/auctions/{}/contracts'.format(
-        self.auction_id),
-        {'data': {'title': 'contract title', 'description': 'contract description', 'awardID': self.award_id}})
-    self.assertEqual(response.status, '201 Created')
-    self.assertEqual(response.content_type, 'application/json')
-    contract = response.json['data']
 
-    response = self.app.get('/auctions/{}/contracts/{}'.format(self.auction_id, contract['id']))
+    response = self.app.get('/auctions/{}/contracts/{}'.format(self.auction_id, self.contract_id))
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
-    self.assertEqual(response.json['data'], contract)
+    self.assertEqual(response.json['data'], self.contract)
 
     response = self.app.get('/auctions/{}/contracts/some_id'.format(self.auction_id), status=404)
     self.assertEqual(response.status, '404 Not Found')

--- a/openprocurement/auctions/core/tests/plugins/contracting/v1/tests/contract.py
+++ b/openprocurement/auctions/core/tests/plugins/contracting/v1/tests/contract.py
@@ -1,3 +1,5 @@
+import unittest
+
 from openprocurement.auctions.core.tests.base import snitch
 from openprocurement.auctions.core.plugins.contracting.v1.tests.blanks.contract_blanks import (
     create_auction_contract,
@@ -7,6 +9,9 @@ from openprocurement.auctions.core.plugins.contracting.v1.tests.blanks.contract_
 
 
 class AuctionContractV1ResourceTestCaseMixin(object):
-    test_create_auction_contract = snitch(create_auction_contract)
-    test_create_auction_contract_in_complete_status = snitch(create_auction_contract_in_complete_status)
+    test_create_auction_contract = unittest.skip('option not available')(
+        snitch(create_auction_contract))
+    test_create_auction_contract_in_complete_status = unittest.skip('option not available')(
+        snitch(create_auction_contract_in_complete_status)
+    )
     test_get_auction_contract = snitch(get_auction_contract)

--- a/openprocurement/auctions/core/tests/plugins/contracting/v2_1/tests/blanks/contract_blanks.py
+++ b/openprocurement/auctions/core/tests/plugins/contracting/v2_1/tests/blanks/contract_blanks.py
@@ -170,8 +170,9 @@ def patch_auction_contract(self):
     #     i['complaintPeriod']['endDate'] = i['complaintPeriod']['startDate']
     # self.db.save(auction)
 
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(self.auction_id, contract['id']), {
-        "data": {"contractID": "myselfID", "items": [{"description": "New Description"}],
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
+    ), {"data": {"contractID": "myselfID", "items": [{"description": "New Description"}],
                  "suppliers": [{"name": "New Name"}]}})
 
     response = self.app.get('/auctions/{}/contracts/{}'.format(self.auction_id, contract['id']))
@@ -179,25 +180,29 @@ def patch_auction_contract(self):
     self.assertEqual(response.json['data']['items'], contract['items'])
     self.assertEqual(response.json['data']['suppliers'], contract['suppliers'])
 
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(self.auction_id, contract['id']),
-                                   {"data": {"value": {"currency": "USD"}}}, status=403)
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
+    ), {"data": {"value": {"currency": "USD"}}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.json['errors'][0]["description"], "Can\'t update currency for contract value")
 
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(self.auction_id, contract['id']),
-                                   {"data": {"value": {"valueAddedTaxIncluded": False}}}, status=403)
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
+    ), {"data": {"value": {"valueAddedTaxIncluded": False}}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.json['errors'][0]["description"],
                      "Can\'t update valueAddedTaxIncluded for contract value")
 
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(self.auction_id, contract['id']),
-                                   {"data": {"value": {"amount": 99}}}, status=403)
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
+    ), {"data": {"value": {"amount": 99}}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.json['errors'][0]["description"],
                      "Value amount should be greater or equal to awarded amount (479.0)")
 
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(self.auction_id, contract['id']),
-                                   {"data": {"value": {"amount": 500}}})
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
+    ), {"data": {"value": {"amount": 500}}})
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.json['data']['value']['amount'], 500)
 
@@ -206,16 +211,18 @@ def patch_auction_contract(self):
     # self.assertEqual(response.json['errors'], [{u'description': [u'Contract signature date should be after award complaint period end date ({})'.format(i['complaintPeriod']['endDate'])], u'location': u'body', u'name': u'dateSigned'}])
 
     one_hour_in_furure = (get_now() + timedelta(hours=1)).isoformat()
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(self.auction_id, contract['id']),
-                                   {"data": {"dateSigned": one_hour_in_furure}}, status=422)
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
+    ), {"data": {"dateSigned": one_hour_in_furure}}, status=422)
     self.assertEqual(response.status, '422 Unprocessable Entity')
     self.assertEqual(response.json['errors'], [
         {u'description': [u"Contract signature date can't be in the future"], u'location': u'body',
          u'name': u'dateSigned'}])
 
     custom_signature_date = get_now().isoformat()
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(self.auction_id, contract['id']),
-                                   {"data": {"dateSigned": custom_signature_date}})
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
+    ), {"data": {"dateSigned": custom_signature_date}})
     self.assertEqual(response.status, '200 OK')
 
     # response = self.app.patch_json('/auctions/{}/contracts/{}'.format(self.auction_id, contract['id']), {"data": {"status": "active"}}, status=403)
@@ -242,38 +249,44 @@ def patch_auction_contract(self):
     # self.assertEqual(response.content_type, 'application/json')
     # self.assertEqual(response.json['data']["status"], "resolved")
 
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(self.auction_id, contract['id']),
-                                   {"data": {"status": "active"}})
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
+    ), {"data": {"status": "active"}})
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['data']["status"], "active")
 
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(self.auction_id, contract['id']),
-                                   {"data": {"value": {"amount": 232}}}, status=403)
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
+    ), {"data": {"value": {"amount": 232}}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.json['errors'][0]["description"],
                      "Can't update contract in current (complete) auction status")
 
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(self.auction_id, contract['id']),
-                                   {"data": {"contractID": "myselfID"}}, status=403)
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
+    ), {"data": {"contractID": "myselfID"}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.json['errors'][0]["description"],
                      "Can't update contract in current (complete) auction status")
 
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(self.auction_id, contract['id']),
-                                   {"data": {"items": [{"description": "New Description"}]}}, status=403)
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
+    ), {"data": {"items": [{"description": "New Description"}]}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.json['errors'][0]["description"],
                      "Can't update contract in current (complete) auction status")
 
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(self.auction_id, contract['id']),
-                                   {"data": {"suppliers": [{"name": "New Name"}]}}, status=403)
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
+    ), {"data": {"suppliers": [{"name": "New Name"}]}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.json['errors'][0]["description"],
                      "Can't update contract in current (complete) auction status")
 
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(self.auction_id, contract['id']),
-                                   {"data": {"status": "active"}}, status=403)
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
+    ), {"data": {"status": "active"}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['errors'][0]["description"],
@@ -310,12 +323,8 @@ def patch_auction_contract(self):
 
 
 def get_auction_contract(self):
-    response = self.app.post_json('/auctions/{}/contracts'.format(
-        self.auction_id),
-        {'data': {'title': 'contract title', 'description': 'contract description', 'awardID': self.award_id}})
-    self.assertEqual(response.status, '201 Created')
-    self.assertEqual(response.content_type, 'application/json')
-    contract = response.json['data']
+    response = self.app.get('/auctions/{}/contracts'.format(self.auction_id))
+    contract = response.json['data'][0]
 
     response = self.app.get('/auctions/{}/contracts/{}'.format(self.auction_id, contract['id']))
     self.assertEqual(response.status, '200 OK')
@@ -341,14 +350,9 @@ def get_auction_contract(self):
     ])
 
 
-
 def get_auction_contracts(self):
-    response = self.app.post_json('/auctions/{}/contracts'.format(
-        self.auction_id),
-        {'data': {'title': 'contract title', 'description': 'contract description', 'awardID': self.award_id}})
-    self.assertEqual(response.status, '201 Created')
-    self.assertEqual(response.content_type, 'application/json')
-    contract = response.json['data']
+    response = self.app.get('/auctions/{}/contracts'.format(self.auction_id))
+    contract = response.json['data'][0]
 
     response = self.app.get('/auctions/{}/contracts'.format(self.auction_id))
     self.assertEqual(response.status, '200 OK')
@@ -375,8 +379,9 @@ def patch_auction_contract_2_lots(self):
     self.assertEqual(response.content_type, 'application/json')
     contract = response.json['data']
 
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(self.auction_id, contract['id']),
-                                   {"data": {"status": "active"}}, status=403)
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
+    ), {"data": {"status": "active"}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertIn("Can't sign contract before stand-still period end (", response.json['errors'][0]["description"])
@@ -390,8 +395,9 @@ def patch_auction_contract_2_lots(self):
         "relatedLot": self.initial_lots[0]['id']
     }})
 
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(self.auction_id, contract['id']),
-                                   {"data": {"status": "active"}}, status=403)
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
+    ), {"data": {"status": "active"}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['errors'][0]["description"], "Can update contract only in active lot status")

--- a/openprocurement/auctions/core/tests/plugins/contracting/v3/tests/blanks/contract_blanks.py
+++ b/openprocurement/auctions/core/tests/plugins/contracting/v3/tests/blanks/contract_blanks.py
@@ -84,16 +84,20 @@ def patch_signing_period(self):
     response = self.app.get('/auctions/{}/contracts'.format(self.auction_id))
     contract = response.json['data'][0]
 
-    response = self.app.post('/auctions/{}/contracts/{}/documents'.format(
-        self.auction_id, contract['id']), upload_files=[('file', 'name.doc', 'content')])
+    response = self.app.post('/auctions/{}/contracts/{}/documents?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
+    ), upload_files=[('file', 'name.doc', 'content')])
     self.assertEqual(response.status, '201 Created')
     self.assertEqual(response.content_type, 'application/json')
 
     # check that signingPeriod can't be patched
-    pre_patch_contract_response = self.app.get('/auctions/{0}/contracts/{1}' \
-        .format(self.auction_id, contract['id']))
+    pre_patch_contract_response = self.app.get('/auctions/{0}/contracts/{1}'.format(
+        self.auction_id, contract['id']
+    ))
     self.app.patch_json(
-        '/auctions/{0}/contracts/{1}'.format(self.auction_id, contract['id']),
+        '/auctions/{0}/contracts/{1}?acc_token={2}'.format(
+            self.auction_id, contract['id'], self.auction_token
+        ),
         {'data': {
             'signingPeriod': {
                 'startDate': '2010-02-02T12:04:15+02:00',
@@ -116,8 +120,9 @@ def patch_date_paid(self):
     response = self.app.get('/auctions/{}/contracts'.format(self.auction_id))
     contract = response.json['data'][0]
 
-    response = self.app.post('/auctions/{}/contracts/{}/documents'.format(
-        self.auction_id, contract['id']), upload_files=[('file', 'name.doc', 'content')])
+    response = self.app.post('/auctions/{}/contracts/{}/documents?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
+    ), upload_files=[('file', 'name.doc', 'content')])
     self.assertEqual(response.status, '201 Created')
     self.assertEqual(response.content_type, 'application/json')
 
@@ -128,13 +133,17 @@ def patch_date_paid(self):
     self.assertIsNone(pre_patch_contract_response.json['data'].get('datePaid'))
 
     self.app.patch_json(
-        '/auctions/{0}/contracts/{1}'.format(self.auction_id, contract['id']),
+        '/auctions/{0}/contracts/{1}?acc_token={2}'.format(
+            self.auction_id, contract['id'], self.auction_token
+        ),
         {'data': {'datePaid': date_paid_iso_str}},
         status=200
     )
 
     after_patch_contract_response = self.app.get(
-        '/auctions/{0}/contracts/{1}'.format(self.auction_id, contract['id'])
+        '/auctions/{0}/contracts/{1}?acc_token={2}'.format(
+            self.auction_id, contract['id'], self.auction_token
+        )
     )
     # check if datePaid has appeared
     self.assertEqual(

--- a/openprocurement/auctions/core/tests/plugins/contracting/v3/tests/blanks/prolongation_blanks.py
+++ b/openprocurement/auctions/core/tests/plugins/contracting/v3/tests/blanks/prolongation_blanks.py
@@ -477,7 +477,8 @@ def get_document(test_case):
         contract_id=test_case.contract_id,
         prolongation_id=test_case.prolongation_id,
         document_id=document_id,
-        key=document_key
+        key=document_key,
+        token=test_case.auction_token
     )
     get_document_response = test_case.app.get(
         url
@@ -548,7 +549,8 @@ def patch_document(test_case):
             contract_id=test_case.contract_id,
             prolongation_id=test_case.prolongation_id,
             document_id=document_id,
-            key=document_key
+            key=document_key,
+            token=test_case.auction_token
         ),
         {'data':
             {'title': 'updated.doc'}

--- a/openprocurement/auctions/core/tests/plugins/contracting/v3/tests/constants.py
+++ b/openprocurement/auctions/core/tests/plugins/contracting/v3/tests/constants.py
@@ -3,5 +3,5 @@ PATHS = {  # resource paths
     'prolongation': '/auctions/{auction_id}/contracts/{contract_id}/prolongations/{prolongation_id}?acc_token={token}',
     'contract': '/auctions/{auction_id}/contracts/{contract_id}?acc_token={token}',
     'prolongation_documents': '/auctions/{auction_id}/contracts/{contract_id}/prolongations/{prolongation_id}/documents?acc_token={token}',
-    'prolongation_document': '/auctions/{auction_id}/contracts/{contract_id}/prolongations/{prolongation_id}/documents/{document_id}?{key}',
+    'prolongation_document': '/auctions/{auction_id}/contracts/{contract_id}/prolongations/{prolongation_id}/documents/{document_id}?{key}&acc_token={token}',
 }

--- a/openprocurement/auctions/core/tests/plugins/contracting/v3/tests/contract.py
+++ b/openprocurement/auctions/core/tests/plugins/contracting/v3/tests/contract.py
@@ -1,3 +1,5 @@
+import unittest
+
 from openprocurement.auctions.core.tests.base import snitch
 from openprocurement.auctions.core.plugins.contracting.v3.tests.blanks.contract_blanks import (
     create_auction_contract,
@@ -9,8 +11,10 @@ from openprocurement.auctions.core.plugins.contracting.v3.tests.blanks.contract_
 
 
 class AuctionContractV3ResourceTestCaseMixin(object):
-    test_create_auction_contract = snitch(create_auction_contract)
-    test_create_auction_contract_in_complete_status = snitch(create_auction_contract_in_complete_status)
+    test_create_auction_contract = unittest.skip('option not available')(snitch(create_auction_contract))
+    test_create_auction_contract_in_complete_status = unittest.skip('option not available')(
+        snitch(create_auction_contract_in_complete_status)
+    )
     test_get_auction_contract = snitch(get_auction_contract)
     test_patch_signing_period = snitch(patch_signing_period)
     test_patch_date_paid = snitch(patch_date_paid)

--- a/openprocurement/auctions/core/tests/plugins/contracting/v3_1/tests/blanks/contract_blanks.py
+++ b/openprocurement/auctions/core/tests/plugins/contracting/v3_1/tests/blanks/contract_blanks.py
@@ -183,8 +183,8 @@ def patch_auction_contract_blacklisted_fields(self):
     contract = response.json['data'][0]
 
     # Trying to patch fields, that are blacklisted for editing.
-    self.app.patch_json('/auctions/{}/contracts/{}'.format(
-        self.auction_id, contract['id']
+    self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
     ), {"data": {"contractID": "myselfID",
                  "items": [{"description": "New Description"}],
                  "suppliers": [{"name": "New Name"}]
@@ -205,8 +205,8 @@ def patch_auction_contract_value(self):
     response = self.app.get('/auctions/{}/contracts'.format(self.auction_id))
     contract = response.json['data'][0]
 
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(
-        self.auction_id, contract['id']
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
     ), {"data": {"value": {"currency": "USD"}}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(
@@ -214,15 +214,15 @@ def patch_auction_contract_value(self):
         "Can't update currency for contract value"
     )
 
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(
-        self.auction_id, contract['id']
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
     ), {"data": {"value": {"valueAddedTaxIncluded": False}}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.json['errors'][0]["description"],
                      "Can\'t update valueAddedTaxIncluded for contract value")
 
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(
-        self.auction_id, contract['id']
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
     ), {"data": {"value": {"amount": 99}}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(
@@ -230,8 +230,8 @@ def patch_auction_contract_value(self):
         "Value amount should be greater or equal to awarded amount (479.0)"
     )
 
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(
-        self.auction_id, contract['id']
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
     ), {"data": {"value": {"amount": 500}}})
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.json['data']['value']['amount'], 500)
@@ -242,8 +242,8 @@ def patch_auction_contract_to_active(self):
     contract = response.json['data'][0]
 
     # Trying to patch contract to active status
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(
-        self.auction_id, contract['id']
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
     ), {"data": {"status": "active"}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
@@ -256,8 +256,8 @@ def patch_auction_contract_to_active(self):
     self.upload_contract_document(contract, 'contract')
 
     # Trying to patch contract to active status again
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(
-        self.auction_id, contract['id']
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
     ), {"data": {"status": "active"}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
@@ -269,8 +269,8 @@ def patch_auction_contract_to_active(self):
 
     # Trying to patch contract's dateSigned field with invalid value
     one_hour_in_future = (get_now() + timedelta(hours=1)).isoformat()
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(
-        self.auction_id, contract['id']
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
     ), {"data": {"dateSigned": one_hour_in_future}}, status=422)
     self.assertEqual(response.status, '422 Unprocessable Entity')
     self.assertEqual(response.json['errors'], [
@@ -281,14 +281,14 @@ def patch_auction_contract_to_active(self):
 
     # Trying to patch contract's dateSigned field with valid value
     custom_signature_date = get_now().isoformat()
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(
-        self.auction_id, contract['id']
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
     ), {"data": {"dateSigned": custom_signature_date}})
     self.assertEqual(response.status, '200 OK')
 
     # Trying to patch contract to active status again
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(
-        self.auction_id, contract['id']
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
     ), {"data": {"status": "active"}})
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
@@ -314,8 +314,8 @@ def patch_auction_contract_to_cancelled_invalid_no_rejection_or_act(self):
     contract = response.json['data'][0]
 
     # Trying to patch contract to cancelled status
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(
-        self.auction_id, contract['id']
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
     ), {"data": {"status": "cancelled"}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
@@ -336,8 +336,8 @@ def patch_auction_contract_to_cancelled_invalid_signed(self):
     self.upload_contract_document(contract, 'rejection')
 
     # Trying to patch contract to cancelled status
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(
-        self.auction_id, contract['id']
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
     ), {"data": {"status": "cancelled"}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
@@ -357,8 +357,8 @@ def patch_auction_contract_to_cancelled_rejection_protocol(self):
     self.upload_contract_document(contract, 'rejection')
 
     # Trying to patch contract to cancelled status
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(
-        self.auction_id, contract['id']
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
     ), {"data": {"status": "cancelled"}})
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
@@ -374,8 +374,8 @@ def patch_auction_contract_to_cancelled_act(self):
     self.upload_contract_document(contract, 'act')
 
     # Trying to patch contract to cancelled status
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(
-        self.auction_id, contract['id']
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
     ), {"data": {"status": "cancelled"}})
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
@@ -390,8 +390,8 @@ def patch_auction_contract_in_auction_complete_status(self):
 
     self.set_status('complete')
 
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(
-        self.auction_id, contract['id']
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
     ), {"data": {"value": {"amount": 232}}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(
@@ -399,8 +399,8 @@ def patch_auction_contract_in_auction_complete_status(self):
         "Can't update contract in current (complete) auction status"
     )
 
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(
-        self.auction_id, contract['id']
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
     ), {"data": {"contractID": "myselfID"}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(
@@ -408,8 +408,8 @@ def patch_auction_contract_in_auction_complete_status(self):
         "Can't update contract in current (complete) auction status"
     )
 
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(
-        self.auction_id, contract['id']
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
     ), {"data": {"items": [{"description": "New Description"}]}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(
@@ -417,8 +417,8 @@ def patch_auction_contract_in_auction_complete_status(self):
         "Can't update contract in current (complete) auction status"
     )
 
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(
-        self.auction_id, contract['id']
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
     ), {"data": {"suppliers": [{"name": "New Name"}]}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(
@@ -426,8 +426,8 @@ def patch_auction_contract_in_auction_complete_status(self):
         "Can't update contract in current (complete) auction status"
     )
 
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(
-        self.auction_id, contract['id']
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
     ), {"data": {"status": "active"}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')

--- a/openprocurement/auctions/core/tests/plugins/contracting/v3_1/tests/contract.py
+++ b/openprocurement/auctions/core/tests/plugins/contracting/v3_1/tests/contract.py
@@ -1,3 +1,5 @@
+import unittest
+
 from openprocurement.auctions.core.tests.base import snitch
 from openprocurement.auctions.core.tests.plugins.contracting.v3_1.tests.blanks.contract_blanks import (
     create_auction_contract,
@@ -16,8 +18,10 @@ from openprocurement.auctions.core.tests.plugins.contracting.v3_1.tests.blanks.c
 
 
 class AuctionContractV3_1ResourceTestCaseMixin(object):
-    test_create_auction_contract = snitch(create_auction_contract)
-    test_create_auction_contract_in_complete_status = snitch(create_auction_contract_in_complete_status)
+    test_create_auction_contract = unittest.skip('option not available')(snitch(create_auction_contract))
+    test_create_auction_contract_in_complete_status = unittest.skip('option not available')(
+        snitch(create_auction_contract_in_complete_status)
+    )
     test_get_auction_contract = snitch(get_auction_contract)
     test_patch_auction_contract_invalid = snitch(patch_auction_contract_invalid)
     test_patch_auction_contract_blacklisted_fields = snitch(patch_auction_contract_blacklisted_fields)

--- a/openprocurement/auctions/core/traversal.py
+++ b/openprocurement/auctions/core/traversal.py
@@ -39,7 +39,7 @@ class Root(object):
         (Allow, 'g:Administrator', 'edit_tender'),
         (Allow, 'g:Administrator', 'edit_auction_award'),
         (Allow, 'g:Administrator', 'edit_bid'),
-        (Allow, 'g:admins', ALL_PERMISSIONS),
+        (Deny, 'g:admins', ALL_PERMISSIONS),
     ]
 
     def __init__(self, request):

--- a/openprocurement/auctions/core/validation.py
+++ b/openprocurement/auctions/core/validation.py
@@ -151,11 +151,11 @@ def validate_auction_auction_data(request, **kwargs):
 
 def validate_bid_data(request, **kwargs):
     if not request.check_accreditation(request.auction.edit_accreditation):
-        request.errors.add('procurementMethodType', 'accreditation', 'Broker Accreditation level does not permit bid creation')
+        request.errors.add('body', 'accreditation', 'Broker Accreditation level does not permit bid creation')
         request.errors.status = 403
         return
     if request.auction.get('mode', None) is None and request.check_accreditation('t'):
-        request.errors.add('procurementMethodType', 'mode', 'Broker Accreditation level does not permit bid creation')
+        request.errors.add('body', 'mode', 'Broker Accreditation level does not permit bid creation')
         request.errors.status = 403
         return
     update_logging_context(request, {'bid_id': '__new__'})


### PR DESCRIPTION
Remove usage of 'admins' token in tests

### Depends on:

- https://github.com/openprocurement/openprocurement.api/pull/372

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.auctions.core/152)
<!-- Reviewable:end -->
