### PR TITLE
Add possibility to patch dateSigned & status:active in single request

### DIFF
--- a/openprocurement/auctions/core/plugins/contracting/v3_1/adapters.py
+++ b/openprocurement/auctions/core/plugins/contracting/v3_1/adapters.py
@@ -114,7 +114,7 @@ class ContractManagerV3_1Adapter(BaseContractManagerAdapter):
                 request.errors.add('body', 'data', 'Can\'t sign contract without contractSigned document')
                 request.errors.status = 403
                 raise error_handler(request)
-            if not request.context.dateSigned:
+            if not request.context.dateSigned and not data.get('dateSigned'):
                 request.errors.add('body', 'data', 'Can\'t sign contract without specified dateSigned field')
                 request.errors.status = 403
                 raise error_handler(request)

--- a/openprocurement/auctions/core/tests/plugins/contracting/v3_1/tests/blanks/contract_blanks.py
+++ b/openprocurement/auctions/core/tests/plugins/contracting/v3_1/tests/blanks/contract_blanks.py
@@ -309,6 +309,61 @@ def patch_auction_contract_to_active(self):
     self.assertEqual(response.json['data']['dateSigned'], custom_signature_date)
 
 
+def patch_auction_contract_to_active_date_signed_burst(self):
+    response = self.app.get('/auctions/{}/contracts'.format(self.auction_id))
+    contract = response.json['data'][0]
+
+    self.upload_contract_document(contract, 'contract')
+
+    # Trying to patch contract's status to 'active' with invalid dateSigned field value
+    one_hour_in_future = (get_now() + timedelta(hours=1)).isoformat()
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
+    ), {"data": {
+        "dateSigned": one_hour_in_future,
+        "status": 'active'
+    }}, status=422)
+    self.assertEqual(response.status, '422 Unprocessable Entity')
+    self.assertEqual(response.json['errors'], [
+        {u'description': [u"Contract signature date can't be in the future"],
+         u'location': u'body',
+         u'name': u'dateSigned'}
+    ])
+
+    # Assuring that contract's has not changed during previous patch
+    response = self.app.get('/auctions/{}/contracts/{}'.format(
+        self.auction_id, contract['id'])
+    )
+    self.assertEqual(response.status, '200 OK')
+    self.assertEqual(response.content_type, 'application/json')
+    self.assertEqual(response.json['data']["status"], "pending")
+
+    # Trying to patch contract's status to 'active' with valid dateSigned field value
+    custom_signature_date = get_now().isoformat()
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
+    ), {"data": {
+        "dateSigned": custom_signature_date,
+        "status": 'active'
+    }})
+    self.assertEqual(response.status, '200 OK')
+
+    # Assuring that contract patched properly
+    response = self.app.get('/auctions/{}/contracts/{}'.format(
+        self.auction_id, contract['id'])
+    )
+    self.assertEqual(response.status, '200 OK')
+    self.assertEqual(response.content_type, 'application/json')
+    self.assertEqual(response.json['data']["status"], "active")
+    self.assertEqual(response.json['data']["value"]['amount'], 479)
+    self.assertEqual(
+        response.json['data']['contractID'], contract['contractID']
+    )
+    self.assertEqual(response.json['data']['items'], contract['items'])
+    self.assertEqual(response.json['data']['suppliers'], contract['suppliers'])
+    self.assertEqual(response.json['data']['dateSigned'], custom_signature_date)
+
+
 def patch_auction_contract_to_cancelled_invalid_no_rejection_or_act(self):
     response = self.app.get('/auctions/{}/contracts'.format(self.auction_id))
     contract = response.json['data'][0]

--- a/openprocurement/auctions/core/tests/plugins/contracting/v3_1/tests/contract.py
+++ b/openprocurement/auctions/core/tests/plugins/contracting/v3_1/tests/contract.py
@@ -7,6 +7,7 @@ from openprocurement.auctions.core.tests.plugins.contracting.v3_1.tests.blanks.c
     patch_auction_contract_blacklisted_fields,
     patch_auction_contract_value,
     patch_auction_contract_to_active,
+    patch_auction_contract_to_active_date_signed_burst,
     patch_auction_contract_in_auction_complete_status,
     patch_auction_contract_to_cancelled_invalid_no_rejection_or_act,
     patch_auction_contract_to_cancelled_invalid_signed,
@@ -23,6 +24,7 @@ class AuctionContractV3_1ResourceTestCaseMixin(object):
     test_patch_auction_contract_blacklisted_fields = snitch(patch_auction_contract_blacklisted_fields)
     test_patch_auction_contract_value = snitch(patch_auction_contract_value)
     test_patch_auction_contract_to_active = snitch(patch_auction_contract_to_active)
+    test_patch_auction_contract_to_active_date_signed_burst = snitch(patch_auction_contract_to_active_date_signed_burst)
     test_patch_auction_contract_in_auction_complete_status = snitch(patch_auction_contract_in_auction_complete_status)
     test_patch_auction_contract_to_cancelled_invalid_no_rejection_or_act = snitch(
         patch_auction_contract_to_cancelled_invalid_no_rejection_or_act


### PR DESCRIPTION
* Update contracting v3.1 tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.auctions.core/162)
<!-- Reviewable:end -->
