### PR TITLE
Turn off contract.value autogeneration

### DIFF
--- a/openprocurement/auctions/core/plugins/awarding/v3_1/adapters.py
+++ b/openprocurement/auctions/core/plugins/awarding/v3_1/adapters.py
@@ -148,8 +148,7 @@ class AwardManagerV3_1Adapter(BaseAwardManagerAdapter):
             auction.contracts.append(type(auction).contracts.model_class({
                 'awardID': award.id,
                 'suppliers': award.suppliers,
-                'value': award.value,
-                'date': get_now(),
+                'date': now,
                 'items': auction.items,
                 'contractID': '{}-{}{}'.format(
                     auction.auctionID,

--- a/openprocurement/auctions/core/plugins/awarding/v3_1/adapters.py
+++ b/openprocurement/auctions/core/plugins/awarding/v3_1/adapters.py
@@ -145,7 +145,7 @@ class AwardManagerV3_1Adapter(BaseAwardManagerAdapter):
                 raise error_handler(request)
 
             award.complaintPeriod.endDate = now
-            auction.contracts.append(type(auction).contracts.model_class({
+            new_contract_data = {
                 'awardID': award.id,
                 'suppliers': award.suppliers,
                 'date': now,
@@ -156,7 +156,11 @@ class AwardManagerV3_1Adapter(BaseAwardManagerAdapter):
                     len(auction.contracts) + 1
                 ),
                 'signingPeriod': award.signingPeriod,
-            }))
+            }
+            if self.COPY_AWARD_VALUE_TO_CONTRACT:
+                new_contract_data['value'] = award.value
+
+            auction.contracts.append(type(auction).contracts.model_class(new_contract_data))
             auction.status = 'active.awarded'
             auction.awardPeriod.endDate = now
 

--- a/openprocurement/auctions/core/plugins/contracting/v3_1/adapters.py
+++ b/openprocurement/auctions/core/plugins/contracting/v3_1/adapters.py
@@ -52,7 +52,7 @@ class ContractManagerV3_1Adapter(BaseContractManagerAdapter):
         data = request.validated['data']
         now = get_now()
 
-        if data.get('value') and context.value is not None:
+        if data.get('value'):
             award = [a for a in auction.awards if a.id == request.context.awardID][0]
             for ro_attr in ('valueAddedTaxIncluded', 'currency'):
                 if data['value'][ro_attr] != getattr(award.value, ro_attr):

--- a/openprocurement/auctions/core/plugins/contracting/v3_1/adapters.py
+++ b/openprocurement/auctions/core/plugins/contracting/v3_1/adapters.py
@@ -52,14 +52,14 @@ class ContractManagerV3_1Adapter(BaseContractManagerAdapter):
         data = request.validated['data']
         now = get_now()
 
-        if data.get('value'):
+        if data.get('value') and context.value is not None:
+            award = [a for a in auction.awards if a.id == request.context.awardID][0]
             for ro_attr in ('valueAddedTaxIncluded', 'currency'):
-                if data['value'][ro_attr] != getattr(context.value, ro_attr):
+                if data['value'][ro_attr] != getattr(award.value, ro_attr):
                     request.errors.add('body', 'data', 'Can\'t update {} for contract value'.format(ro_attr))
                     request.errors.status = 403
                     raise error_handler(request)
 
-            award = [a for a in auction.awards if a.id == request.context.awardID][0]
             if data['value']['amount'] < award.value.amount:
                 request.errors.add('body', 'data', 'Value amount should be greater or equal to awarded amount ({})'.format(award.value.amount))
                 request.errors.status = 403
@@ -118,6 +118,14 @@ class ContractManagerV3_1Adapter(BaseContractManagerAdapter):
                 request.errors.add('body', 'data', 'Can\'t sign contract without specified dateSigned field')
                 request.errors.status = 403
                 raise error_handler(request)
+            if not (
+                data.get('value')  # there's value passed
+                or context.value is not None  # there's value defined
+            ):
+                request.errors.add('body', 'data', 'Can\'t activate contract without value defined')
+                request.errors.status = 403
+                raise error_handler(request)
+
         current_contract_status = request.context.status
         apply_patch(request, save=False, src=request.context.serialize())
         if current_contract_status != request.context.status and (


### PR DESCRIPTION
- Update contract tests
- Now they didnt't assume that value is autogenerated
- Require contract value to activate contract
- Adapt tests to value's presence

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.auctions.core/201)
<!-- Reviewable:end -->
